### PR TITLE
Bump Docker PHP from 7.0 to 7.1

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,6 +1,6 @@
 FROM composer:2.2.25 AS composer
 
-FROM php:7.0-cli
+FROM php:7.1-cli
 
 RUN set -eux; \
     printf '%s\n' \

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,11 +1,11 @@
 FROM composer:2.2.25 AS composer
 
-FROM php:7.1-cli
+FROM php:7.1-cli-buster
 
 RUN set -eux; \
     printf '%s\n' \
-        'deb [trusted=yes] http://archive.debian.org/debian stretch main' \
-        'deb [trusted=yes] http://archive.debian.org/debian-security stretch/updates main' \
+        'deb [trusted=yes] http://archive.debian.org/debian buster main' \
+        'deb [trusted=yes] http://archive.debian.org/debian-security buster/updates main' \
         > /etc/apt/sources.list; \
     echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until; \
     apt-get update; \


### PR DESCRIPTION
Bumps PHP Docker image from `php:7.0-cli` to `php:7.1-cli-buster`. Buster base required to avoid archived Stretch package conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)