### PR TITLE
Fix Docker root HTTP smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,5 +59,5 @@ jobs:
       - name: HTTP smoke test
         run: |
           docker compose up --wait php
-          curl -fsSI --max-time 10 http://localhost:8000/app_dev.php/
+          curl -fsSI --max-time 10 http://localhost:8000/
 

--- a/TODO.md
+++ b/TODO.md
@@ -40,6 +40,6 @@ docker compose run --rm php php bin/console doctrine:schema:update --force
 docker compose run --rm php php bin/console doctrine:schema:validate
 docker compose run --rm php vendor/bin/simple-phpunit --testsuite 'Project Test Suite'
 docker compose up --wait php
-curl -fsSI --max-time 10 http://localhost:8000/app_dev.php/
+curl -fsSI --max-time 10 http://localhost:8000/
 docker compose down -v
 ```

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -170,7 +170,7 @@ fos_oauth_server:
     refresh_token_class: Devlabs\SportifyBundle\Entity\OAuthRefreshToken
     auth_code_class:     Devlabs\SportifyBundle\Entity\OAuthAuthCode
     service:
-        user_provider: fos_user.user_manager
+        user_provider: fos_user.user_provider.username_email
         options:
             access_token_lifetime: 7776000 # 90 days in seconds
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,14 +17,14 @@ services:
         condition: service_healthy
     ports:
       - "8000:8000"
-    command: php -S 0.0.0.0:8000 -t web app_dev.php
+    command: php -S 0.0.0.0:8000 -t web /app/web/app_dev.php
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8000/app_dev.php/ >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "curl -fsS http://127.0.0.1:8000/ >/dev/null || exit 1"]
       interval: 5m
       timeout: 5s
       retries: 20
       start_period: 5s
-      start_interval: 5s
+      start_interval: 20s
 
   node:
     build:


### PR DESCRIPTION
Fix the Docker router script path and make the healthcheck/CI smoke test cover the root URL.