### PR TITLE
Document Doctrine cache bundle constraint

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,14 +14,15 @@
 - Symfony deprecation notices have been reduced to the remaining vendor-level batch.
 - Composer package constraints have been reviewed for the current Symfony 3.4/PHP 7.4 baseline; unused `sensio/generator-bundle` was removed and `doctrine/doctrine-cache-bundle` is no longer a direct dependency.
 - Remaining abandoned packages are tied to the legacy Symfony 3.4 stack and should be handled as separate migrations.
+- `doctrine/doctrine-cache-bundle` cannot be removed while staying on Symfony 3.4 because the latest compatible `doctrine/doctrine-bundle` 1.x requires it; `doctrine/doctrine-bundle` 2.x removes that dependency but requires Symfony 4.3+.
 - Current abandoned packages in `composer.lock`: `doctrine/annotations`, `doctrine/cache`, `doctrine/doctrine-cache-bundle`, `doctrine/reflection`, `sensio/framework-extra-bundle`, `swiftmailer/swiftmailer`, and `symfony/swiftmailer-bundle`.
 
 ## Next steps
 
-1. Investigate whether `doctrine/doctrine-cache-bundle` can be removed or upgraded indirectly by adjusting `doctrine/doctrine-bundle` within the Symfony 3.4/PHP 7.4 constraints.
-2. Keep `sensio/framework-extra-bundle`/`doctrine/annotations` work separate because controllers currently rely on annotation routes/security; plan that migration before a Symfony major upgrade.
-3. Keep `symfony/swiftmailer-bundle`/`swiftmailer/swiftmailer` migration separate; replacing it with `symfony/mailer` likely belongs with a later Symfony upgrade.
-4. Keep frontend upgrade work separate from PHP/Symfony upgrade work.
+1. Keep `sensio/framework-extra-bundle`/`doctrine/annotations` work separate because controllers currently rely on annotation routes/security; plan that migration before a Symfony major upgrade.
+2. Keep `symfony/swiftmailer-bundle`/`swiftmailer/swiftmailer` migration separate; replacing it with `symfony/mailer` likely belongs with a later Symfony upgrade.
+3. Keep frontend upgrade work separate from PHP/Symfony upgrade work.
+4. Plan the backend upgrade path toward Symfony 7.4 LTS as the long-term framework target.
 
 ## Always verify each step
 


### PR DESCRIPTION
Documents why doctrine/doctrine-cache-bundle cannot be removed on the current Symfony 3.4 baseline and adds Symfony 7.4 LTS as the long-term target.