### PR TITLE
Remove SensioFrameworkExtraBundle

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,11 +15,12 @@
 - Composer package constraints have been reviewed for the current Symfony 3.4/PHP 7.4 baseline; unused `sensio/generator-bundle` was removed and `doctrine/doctrine-cache-bundle` is no longer a direct dependency.
 - Remaining abandoned packages are tied to the legacy Symfony 3.4 stack and should be handled as separate migrations.
 - `doctrine/doctrine-cache-bundle` cannot be removed while staying on Symfony 3.4 because the latest compatible `doctrine/doctrine-bundle` 1.x requires it; `doctrine/doctrine-bundle` 2.x removes that dependency but requires Symfony 4.3+.
-- Current abandoned packages in `composer.lock`: `doctrine/annotations`, `doctrine/cache`, `doctrine/doctrine-cache-bundle`, `doctrine/reflection`, `sensio/framework-extra-bundle`, `swiftmailer/swiftmailer`, and `symfony/swiftmailer-bundle`.
+- SensioFrameworkExtraBundle has been removed; controller routes now use Symfony's core `Route` annotation, and former admin-only security annotations are explicit controller checks.
+- Current abandoned packages in `composer.lock`: `doctrine/annotations`, `doctrine/cache`, `doctrine/doctrine-cache-bundle`, `doctrine/reflection`, `swiftmailer/swiftmailer`, and `symfony/swiftmailer-bundle`.
 
 ## Next steps
 
-1. Keep `sensio/framework-extra-bundle`/`doctrine/annotations` work separate because controllers currently rely on annotation routes/security; plan that migration before a Symfony major upgrade.
+1. Keep `doctrine/annotations` work separate because entities, validation, API docs, and controller routes still rely on annotations; plan that migration before a Symfony major upgrade.
 2. Keep `symfony/swiftmailer-bundle`/`swiftmailer/swiftmailer` migration separate; replacing it with `symfony/mailer` likely belongs with a later Symfony upgrade.
 3. Keep frontend upgrade work separate from PHP/Symfony upgrade work.
 4. Plan the backend upgrade path toward Symfony 7.4 LTS as the long-term framework target.

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -14,7 +14,6 @@ class AppKernel extends Kernel
             new Symfony\Bundle\MonologBundle\MonologBundle(),
             new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
-            new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new FOS\UserBundle\FOSUserBundle(),
             new Devlabs\SportifyBundle\DevlabsSportifyBundle(),
             new FOS\RestBundle\FOSRestBundle(),

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -38,9 +38,6 @@ framework:
     http_method_override: true
     assets: ~
 
-#sensio_framework_extra:
-#    request: { converters: true }
-
 # Twig Configuration
 twig:
     debug:            "%kernel.debug%"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,6 @@
         "symfony/swiftmailer-bundle": "^2.3",
         "symfony/monolog-bundle": "^2.8",
         "symfony/polyfill-apcu": "^1.0",
-        "sensio/framework-extra-bundle": "^3.0.2",
         "incenteev/composer-parameter-handler": "^2.0",
         "friendsofsymfony/user-bundle": "~2.0@dev",
         "guzzlehttp/guzzle": "~6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c6e696bc4842bb5bd1dad6083cf815d",
+    "content-hash": "83bef7f93ed5c573b64379adfdd7f248",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -3307,81 +3307,6 @@
                 "source": "https://github.com/ralouphie/getallheaders/tree/develop"
             },
             "time": "2019-03-08T08:55:37+00:00"
-        },
-        {
-            "name": "sensio/framework-extra-bundle",
-            "version": "v3.0.29",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sensiolabs/SensioFrameworkExtraBundle.git",
-                "reference": "bb907234df776b68922eb4b25bfa061683597b6a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/bb907234df776b68922eb4b25bfa061683597b6a",
-                "reference": "bb907234df776b68922eb4b25bfa061683597b6a",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/common": "~2.2",
-                "symfony/dependency-injection": "~2.3|~3.0",
-                "symfony/framework-bundle": "~2.3|~3.0|~4.0"
-            },
-            "require-dev": {
-                "doctrine/doctrine-bundle": "~1.5",
-                "doctrine/orm": "~2.4,>=2.4.5",
-                "symfony/asset": "~2.7|~3.0|~4.0",
-                "symfony/browser-kit": "~2.3|~3.0|~4.0",
-                "symfony/dom-crawler": "~2.3|~3.0|~4.0",
-                "symfony/expression-language": "~2.4|~3.0|~4.0",
-                "symfony/finder": "~2.3|~3.0|~4.0",
-                "symfony/phpunit-bridge": "~3.2|~4.0",
-                "symfony/psr-http-message-bridge": "^0.3|^1.0",
-                "symfony/security-bundle": "~2.4|~3.0|~4.0",
-                "symfony/templating": "~2.3|~3.0|~4.0",
-                "symfony/translation": "~2.3|~3.0|~4.0",
-                "symfony/twig-bundle": "~2.3|~3.0|~4.0",
-                "symfony/yaml": "~2.3|~3.0|~4.0",
-                "twig/twig": "~1.12|~2.0",
-                "zendframework/zend-diactoros": "^1.3"
-            },
-            "suggest": {
-                "symfony/expression-language": "",
-                "symfony/psr-http-message-bridge": "To use the PSR-7 converters",
-                "symfony/security-bundle": ""
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Sensio\\Bundle\\FrameworkExtraBundle\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                }
-            ],
-            "description": "This bundle provides a way to configure your controllers with annotations",
-            "keywords": [
-                "annotations",
-                "controllers"
-            ],
-            "support": {
-                "issues": "https://github.com/sensiolabs/SensioFrameworkExtraBundle/issues",
-                "source": "https://github.com/sensiolabs/SensioFrameworkExtraBundle/tree/3.0"
-            },
-            "abandoned": "Symfony",
-            "time": "2017-12-14T19:03:23+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",

--- a/src/Devlabs/SportifyBundle/Controller/AdminController.php
+++ b/src/Devlabs/SportifyBundle/Controller/AdminController.php
@@ -3,7 +3,7 @@
 namespace Devlabs\SportifyBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use Devlabs\SportifyBundle\Entity\ApiMapping;
 use Devlabs\SportifyBundle\Entity\Tournament;

--- a/src/Devlabs/SportifyBundle/Controller/Api/MatchController.php
+++ b/src/Devlabs/SportifyBundle/Controller/Api/MatchController.php
@@ -5,7 +5,6 @@ namespace Devlabs\SportifyBundle\Controller\Api;
 use Devlabs\SportifyBundle\Controller\Base\BaseApiController;
 use Devlabs\SportifyBundle\Entity\Match;
 use Devlabs\SportifyBundle\Form\MatchEntityType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 
 /**
@@ -31,12 +30,14 @@ class MatchController extends BaseApiController
      *     }
      * )
      *
-     * @Security("has_role('ROLE_ADMIN')")
-     *
      * @return \FOS\RestBundle\View\View
      */
     public function getPredictionsAllusersAction($id)
     {
+        if (!$this->isGranted('ROLE_ADMIN')) {
+            return $this->view(null, 403);
+        }
+
         $match = $this->getDoctrine()->getManager()
             ->getRepository($this->repositoryName)
             ->findOneById($id);

--- a/src/Devlabs/SportifyBundle/Controller/Api/PredictionController.php
+++ b/src/Devlabs/SportifyBundle/Controller/Api/PredictionController.php
@@ -7,7 +7,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Devlabs\SportifyBundle\Entity\User;
 use Devlabs\SportifyBundle\Entity\Prediction;
 use Devlabs\SportifyBundle\Form\PredictionType;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 
 /**
@@ -33,13 +32,15 @@ class PredictionController extends BaseApiController
      *     }
      * )
      *
-     * @Security("has_role('ROLE_ADMIN')")
-     *
      * @param Request $request
      * @return \FOS\RestBundle\View\View
      */
     public function cgetAllusersAction(Request $request)
     {
+        if (!$this->isGranted('ROLE_ADMIN')) {
+            return $this->view(null, 403);
+        }
+
         // get an array of all the query string key-value pairs
         $params = $request->query->all();
 

--- a/src/Devlabs/SportifyBundle/Controller/Base/BaseApiController.php
+++ b/src/Devlabs/SportifyBundle/Controller/Base/BaseApiController.php
@@ -6,7 +6,6 @@ use FOS\RestBundle\Controller\FOSRestController;
 use FOS\RestBundle\Routing\ClassResourceInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Doctrine\Common\Persistence\ObjectManager;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 
 /**
@@ -117,13 +116,15 @@ abstract class BaseApiController extends FOSRestController implements ClassResou
      *     }
      * )
      *
-     * @Security("has_role('ROLE_ADMIN')")
-     *
      * @param Request $request
      * @return \FOS\RestBundle\View\View
      */
     public function postAction(Request $request)
     {
+        if (!$this->isGranted('ROLE_ADMIN')) {
+            return $this->view(null, 403);
+        }
+
         // if user is not logged in, return unauthorized
         if (!is_object($user = $this->getUser())) {
             return $this->getUnauthorizedView();
@@ -155,14 +156,16 @@ abstract class BaseApiController extends FOSRestController implements ClassResou
      *     }
      * )
      *
-     * @Security("has_role('ROLE_ADMIN')")
-     *
      * @param Request $request
      * @param $id
      * @return \FOS\RestBundle\View\View
      */
     public function putAction(Request $request, $id)
     {
+        if (!$this->isGranted('ROLE_ADMIN')) {
+            return $this->view(null, 403);
+        }
+
         // if user is not logged in, return unauthorized
         if (!is_object($user = $this->getUser())) {
             return $this->getUnauthorizedView();
@@ -201,14 +204,16 @@ abstract class BaseApiController extends FOSRestController implements ClassResou
      *     }
      * )
      *
-     * @Security("has_role('ROLE_ADMIN')")
-     *
      * @param Request $request
      * @param $id
      * @return \FOS\RestBundle\View\View
      */
     public function patchAction(Request $request, $id)
     {
+        if (!$this->isGranted('ROLE_ADMIN')) {
+            return $this->view(null, 403);
+        }
+
         // if user is not logged in, return unauthorized
         if (!is_object($user = $this->getUser())) {
             return $this->getUnauthorizedView();
@@ -244,13 +249,15 @@ abstract class BaseApiController extends FOSRestController implements ClassResou
      *     }
      * )
      *
-     * @Security("has_role('ROLE_ADMIN')")
-     *
      * @param $id
      * @return \FOS\RestBundle\View\View
      */
     public function deleteAction($id)
     {
+        if (!$this->isGranted('ROLE_ADMIN')) {
+            return $this->view(null, 403);
+        }
+
         // if user is not logged in, return unauthorized
         if (!is_object($user = $this->getUser())) {
             return $this->getUnauthorizedView();

--- a/src/Devlabs/SportifyBundle/Controller/ChampionController.php
+++ b/src/Devlabs/SportifyBundle/Controller/ChampionController.php
@@ -3,7 +3,7 @@
 namespace Devlabs\SportifyBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 
 /**

--- a/src/Devlabs/SportifyBundle/Controller/DefaultController.php
+++ b/src/Devlabs/SportifyBundle/Controller/DefaultController.php
@@ -3,7 +3,7 @@
 namespace Devlabs\SportifyBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 
 class DefaultController extends Controller
 {

--- a/src/Devlabs/SportifyBundle/Controller/HistoryController.php
+++ b/src/Devlabs/SportifyBundle/Controller/HistoryController.php
@@ -3,7 +3,7 @@
 namespace Devlabs\SportifyBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 
 /**

--- a/src/Devlabs/SportifyBundle/Controller/MatchesController.php
+++ b/src/Devlabs/SportifyBundle/Controller/MatchesController.php
@@ -4,7 +4,7 @@ namespace Devlabs\SportifyBundle\Controller;
 
 use Devlabs\SportifyBundle\Entity\Prediction;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 
 /**

--- a/src/Devlabs/SportifyBundle/Controller/RulesController.php
+++ b/src/Devlabs/SportifyBundle/Controller/RulesController.php
@@ -3,7 +3,7 @@
 namespace Devlabs\SportifyBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 
 class RulesController extends Controller
 {

--- a/src/Devlabs/SportifyBundle/Controller/ScoresUpdateController.php
+++ b/src/Devlabs/SportifyBundle/Controller/ScoresUpdateController.php
@@ -3,7 +3,7 @@
 namespace Devlabs\SportifyBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Class ScoresUpdateController

--- a/src/Devlabs/SportifyBundle/Controller/StandingsController.php
+++ b/src/Devlabs/SportifyBundle/Controller/StandingsController.php
@@ -3,7 +3,7 @@
 namespace Devlabs\SportifyBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Cookie;

--- a/src/Devlabs/SportifyBundle/Controller/TournamentsController.php
+++ b/src/Devlabs/SportifyBundle/Controller/TournamentsController.php
@@ -4,7 +4,7 @@ namespace Devlabs\SportifyBundle\Controller;
 
 use Devlabs\SportifyBundle\Entity\Score;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;

--- a/src/Devlabs/SportifyBundle/Controller/UserController.php
+++ b/src/Devlabs/SportifyBundle/Controller/UserController.php
@@ -3,7 +3,7 @@
 namespace Devlabs\SportifyBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\HttpFoundation\Request;
 use Devlabs\SportifyBundle\Form\UserType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;


### PR DESCRIPTION
Removes SensioFrameworkExtraBundle by switching controller route annotations to Symfony core annotations and replacing admin-only security annotations with explicit checks.