### PR TITLE
Move validation constraints to YAML

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,11 +17,12 @@
 - `doctrine/doctrine-cache-bundle` cannot be removed while staying on Symfony 3.4 because the latest compatible `doctrine/doctrine-bundle` 1.x requires it; `doctrine/doctrine-bundle` 2.x removes that dependency but requires Symfony 4.3+.
 - SensioFrameworkExtraBundle has been removed; former admin-only security annotations are explicit controller checks.
 - Web controller routes have been moved from annotations to YAML routing.
+- App validation constraints have been moved from annotations to YAML, and Symfony validator annotation loading is disabled.
 - Current abandoned packages in `composer.lock`: `doctrine/annotations`, `doctrine/cache`, `doctrine/doctrine-cache-bundle`, `doctrine/reflection`, `swiftmailer/swiftmailer`, and `symfony/swiftmailer-bundle`.
 
 ## Next steps
 
-1. Keep remaining `doctrine/annotations` work separate because entities, validation, and API docs still rely on annotations; plan that migration before a Symfony major upgrade.
+1. Keep remaining `doctrine/annotations` work separate because Doctrine ORM mappings and API docs still rely on annotations; plan that migration before a Symfony major upgrade.
 2. Keep `symfony/swiftmailer-bundle`/`swiftmailer/swiftmailer` migration separate; replacing it with `symfony/mailer` likely belongs with a later Symfony upgrade.
 3. Keep frontend upgrade work separate from PHP/Symfony upgrade work.
 4. Plan the backend upgrade path toward Symfony 7.4 LTS as the long-term framework target.

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -22,7 +22,7 @@ framework:
         strict_requirements: ~
     form:            ~
     csrf_protection: ~
-    validation:      { enable_annotations: true }
+    validation:      ~
 #    serializer:
 #        enabled: true
 #        enable_annotations: true

--- a/src/Devlabs/SportifyBundle/Entity/Prediction.php
+++ b/src/Devlabs/SportifyBundle/Entity/Prediction.php
@@ -3,7 +3,6 @@
 namespace Devlabs\SportifyBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ORM\Entity(repositoryClass="Devlabs\SportifyBundle\Entity\PredictionRepository")
@@ -37,19 +36,11 @@ class Prediction
 
     /**
      * @ORM\Column(type="integer", name="home_goals")
-     * @Assert\Type(
-     *     type="integer",
-     *     message="The value {{ value }} is not a valid {{ type }}."
-     * )
      */
     private $homeGoals;
 
     /**
      * @ORM\Column(type="integer", name="away_goals")
-     * @Assert\Type(
-     *     type="integer",
-     *     message="The value {{ value }} is not a valid {{ type }}."
-     * )
      */
     private $awayGoals;
 

--- a/src/Devlabs/SportifyBundle/Entity/PredictionChampion.php
+++ b/src/Devlabs/SportifyBundle/Entity/PredictionChampion.php
@@ -3,7 +3,6 @@
 namespace Devlabs\SportifyBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ORM\Entity(repositoryClass="Devlabs\SportifyBundle\Entity\PredictionChampionRepository")

--- a/src/Devlabs/SportifyBundle/Resources/config/validation.yml
+++ b/src/Devlabs/SportifyBundle/Resources/config/validation.yml
@@ -1,0 +1,10 @@
+Devlabs\SportifyBundle\Entity\Prediction:
+    properties:
+        homeGoals:
+            - Type:
+                type: integer
+                message: 'The value {{ value }} is not a valid {{ type }}.'
+        awayGoals:
+            - Type:
+                type: integer
+                message: 'The value {{ value }} is not a valid {{ type }}.'

--- a/tests/Integration/ValidationMappingTest.php
+++ b/tests/Integration/ValidationMappingTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Integration;
+
+use Devlabs\SportifyBundle\Entity\Prediction;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class ValidationMappingTest extends KernelTestCase
+{
+    public function testPredictionGoalConstraintsLoadFromYaml()
+    {
+        self::bootKernel();
+
+        $prediction = new Prediction();
+        $prediction->setHomeGoals('invalid');
+        $prediction->setAwayGoals('invalid');
+
+        $violations = self::$kernel->getContainer()
+            ->get('validator')
+            ->validate($prediction);
+
+        $this->assertCount(2, $violations);
+    }
+}


### PR DESCRIPTION
Moves app validation constraints out of annotations and disables Symfony validator annotation loading.