### PR TITLE
Remove manual annotation registry setup

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,6 +18,7 @@
 - SensioFrameworkExtraBundle has been removed; former admin-only security annotations are explicit controller checks.
 - Web controller routes have been moved from annotations to YAML routing.
 - App validation constraints have been moved from annotations to YAML, and Symfony validator annotation loading is disabled.
+- The app bootstrap no longer manually registers Doctrine's annotation autoloader.
 - Current abandoned packages in `composer.lock`: `doctrine/annotations`, `doctrine/cache`, `doctrine/doctrine-cache-bundle`, `doctrine/reflection`, `swiftmailer/swiftmailer`, and `symfony/swiftmailer-bundle`.
 
 ## Next steps

--- a/app/autoload.php
+++ b/app/autoload.php
@@ -1,13 +1,10 @@
 <?php
 
-use Doctrine\Common\Annotations\AnnotationRegistry;
 use Composer\Autoload\ClassLoader;
 
 /**
  * @var ClassLoader $loader
  */
 $loader = require __DIR__.'/../vendor/autoload.php';
-
-AnnotationRegistry::registerLoader([$loader, 'loadClass']);
 
 return $loader;


### PR DESCRIPTION
Removes the app-level Doctrine AnnotationRegistry bootstrap; current dependencies autoload annotations without it.