### PR TITLE
Remove direct Doctrine annotations dependency

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,6 +19,7 @@
 - Web controller routes have been moved from annotations to YAML routing.
 - App validation constraints have been moved from annotations to YAML, and Symfony validator annotation loading is disabled.
 - The app bootstrap no longer manually registers Doctrine's annotation autoloader.
+- `doctrine/annotations` is no longer a direct dependency; it remains installed transitively through Doctrine ORM/common/persistence, JMS serializer, and Hateoas.
 - Current abandoned packages in `composer.lock`: `doctrine/annotations`, `doctrine/cache`, `doctrine/doctrine-cache-bundle`, `doctrine/reflection`, `swiftmailer/swiftmailer`, and `symfony/swiftmailer-bundle`.
 
 ## Next steps

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "php": ">=5.5.9",
         "symfony/symfony": "3.4.*",
         "doctrine/orm": "^2.5",
-        "doctrine/annotations": "^1.8",
         "doctrine/doctrine-bundle": "^1.6",
         "symfony/swiftmailer-bundle": "^2.3",
         "symfony/monolog-bundle": "^2.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "83bef7f93ed5c573b64379adfdd7f248",
+    "content-hash": "57ba7db5ee76d610a817326b4b965e04",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",


### PR DESCRIPTION
Removes the direct doctrine/annotations Composer constraint; the package remains installed transitively until Doctrine/JMS/Hateoas annotation usage is migrated.