### PR TITLE
Move team unique constraint to YAML

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,6 +18,7 @@
 - SensioFrameworkExtraBundle has been removed; former admin-only security annotations are explicit controller checks.
 - Web controller routes have been moved from annotations to YAML routing.
 - App validation constraints have been moved from annotations to YAML, and Symfony validator annotation loading is disabled.
+- The leftover `Team` unique-entity validation annotation has been moved to YAML.
 - The app bootstrap no longer manually registers Doctrine's annotation autoloader.
 - `doctrine/annotations` is no longer a direct dependency; it remains installed transitively through Doctrine ORM/common/persistence, JMS serializer, and Hateoas.
 - `symfony/mailer` is not installable on the current `symfony/symfony:3.4.*` baseline because Symfony Mailer 4.4+/5.4 requires newer Symfony components; current email usage is FOSUserBundle registration/resetting through `fos_user.mailer.twig_swift`.

--- a/src/Devlabs/SportifyBundle/Entity/Team.php
+++ b/src/Devlabs/SportifyBundle/Entity/Team.php
@@ -3,7 +3,6 @@
 namespace Devlabs\SportifyBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Routing\RequestContext;
 use Intervention\Image\ImageManager;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -11,7 +10,6 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 /**
  * @ORM\Entity(repositoryClass="Devlabs\SportifyBundle\Entity\TeamRepository")
  * @ORM\Table(name="teams")
- * @UniqueEntity("name")
  */
 class Team
 {

--- a/src/Devlabs/SportifyBundle/Resources/config/validation.yml
+++ b/src/Devlabs/SportifyBundle/Resources/config/validation.yml
@@ -1,3 +1,8 @@
+Devlabs\SportifyBundle\Entity\Team:
+    constraints:
+        - Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity:
+            fields: name
+
 Devlabs\SportifyBundle\Entity\Prediction:
     properties:
         homeGoals:

--- a/tests/Integration/ValidationMappingTest.php
+++ b/tests/Integration/ValidationMappingTest.php
@@ -3,10 +3,28 @@
 namespace Tests\Integration;
 
 use Devlabs\SportifyBundle\Entity\Prediction;
+use Devlabs\SportifyBundle\Entity\Team;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 class ValidationMappingTest extends KernelTestCase
 {
+    public function testTeamUniqueEntityConstraintLoadsFromYaml()
+    {
+        self::bootKernel();
+
+        $metadata = self::$kernel->getContainer()
+            ->get('validator')
+            ->getMetadataFor(Team::class);
+
+        $constraints = array_filter($metadata->getConstraints(), function ($constraint) {
+            return $constraint instanceof UniqueEntity;
+        });
+
+        $this->assertCount(1, $constraints);
+        $this->assertSame('name', array_values($constraints)[0]->fields);
+    }
+
     public function testPredictionGoalConstraintsLoadFromYaml()
     {
         self::bootKernel();


### PR DESCRIPTION
Moves the remaining Team UniqueEntity validation constraint out of annotations and extends the validation mapping test.