### PR TITLE
Replace Doctrine short entity aliases with FQCN

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,7 +19,7 @@
 - Composer package constraints have been reviewed for the current Symfony 4.4/PHP 7.4 baseline; unused `sensio/generator-bundle` was removed and `doctrine/doctrine-cache-bundle` is no longer a direct dependency.
 - Remaining abandoned packages are tied to legacy dependencies and should be handled as separate migrations.
 - `doctrine/doctrine-bundle` has been upgraded to 2.7, Doctrine ORM to 2.20, Doctrine DBAL is pinned to 2.13, Doctrine Persistence is pinned to 2.5, and `doctrine/doctrine-cache-bundle`/`doctrine/reflection` have been removed.
-- Minimal app bridge managers/listeners keep FOSUserBundle/FOSOAuthServerBundle working with `Doctrine\Persistence`; remaining short entity aliases should be migrated before Doctrine Persistence 3.
+- Minimal app bridge managers/listeners keep FOSUserBundle/FOSOAuthServerBundle working with `Doctrine\Persistence`; short `DevlabsSportifyBundle:Entity` aliases in app code have been replaced with FQCN/`::class`, and remaining short aliases live only in vendor bridges.
 - SensioFrameworkExtraBundle has been removed; former admin-only security annotations are explicit controller checks.
 - Web controller routes have been moved from annotations to YAML routing.
 - App validation constraints have been moved from annotations to YAML, and Symfony validator annotation loading is disabled.

--- a/src/Devlabs/SportifyBundle/Command/CreateOAuthClientCommand.php
+++ b/src/Devlabs/SportifyBundle/Command/CreateOAuthClientCommand.php
@@ -2,6 +2,7 @@
 
 namespace Devlabs\SportifyBundle\Command;
 
+use Devlabs\SportifyBundle\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -62,7 +63,7 @@ class CreateOAuthClientCommand extends ContainerAwareCommand
         );
 
         $users = $container->get('doctrine')
-            ->getRepository('DevlabsSportifyBundle:User')
+            ->getRepository(User::class)
             ->findAll();
 
         foreach ($users as $user) {

--- a/src/Devlabs/SportifyBundle/Command/DataUpdateCommand.php
+++ b/src/Devlabs/SportifyBundle/Command/DataUpdateCommand.php
@@ -2,6 +2,7 @@
 
 namespace Devlabs\SportifyBundle\Command;
 
+use Devlabs\SportifyBundle\Entity\Score;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -66,7 +67,7 @@ class DataUpdateCommand extends ContainerAwareCommand
                 $tournamentsModified = $this->getContainer()
                     ->get('app.score_updater')->updateAll();
 
-                $scores = $em->getRepository('DevlabsSportifyBundle:Score')
+                $scores = $em->getRepository(Score::class)
                     ->getAllHashed();
 
                 $dataUpdated = true;

--- a/src/Devlabs/SportifyBundle/Command/NotifyCommand.php
+++ b/src/Devlabs/SportifyBundle/Command/NotifyCommand.php
@@ -2,6 +2,8 @@
 
 namespace Devlabs\SportifyBundle\Command;
 
+use Devlabs\SportifyBundle\Entity\Match;
+use Devlabs\SportifyBundle\Entity\User;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -39,7 +41,7 @@ class NotifyCommand extends ContainerAwareCommand
             $em = $this->getContainer()->get('doctrine')->getManager();
 
             // get the upcoming matches for the next 1 hour
-            $matches = $em->getRepository('DevlabsSportifyBundle:Match')
+            $matches = $em->getRepository(Match::class)
                 ->getUpcoming($dateFrom, $dateTo);
 
             // array for holding the users' messages
@@ -65,7 +67,7 @@ class NotifyCommand extends ContainerAwareCommand
                     $logText = $logText . "\n" . "Match: " . $matchText . "\n";
 
                     // get the users which have no prediction for this match
-                    $usersNotPredictedByMatch = $em->getRepository('DevlabsSportifyBundle:User')
+                    $usersNotPredictedByMatch = $em->getRepository(User::class)
                         ->getNotPredictedByMatch($match);
 
                     // creating the messages for each user
@@ -94,7 +96,7 @@ class NotifyCommand extends ContainerAwareCommand
                  */
                 foreach ($messages as $id => $message) {
                     // get the user for the message
-                    $user = $em->getRepository('DevlabsSportifyBundle:User')
+                    $user = $em->getRepository(User::class)
                         ->findOneById($id);
 
                     // send the notification

--- a/src/Devlabs/SportifyBundle/Controller/AdminController.php
+++ b/src/Devlabs/SportifyBundle/Controller/AdminController.php
@@ -131,7 +131,7 @@ class AdminController extends Controller
         $adminHelper = $this->container->get('app.admin.helper');
 
         // get all tournaments
-        $tournaments = $em->getRepository('DevlabsSportifyBundle:Tournament')
+        $tournaments = $em->getRepository(Tournament::class)
             ->findAll();
 
         // create Tournament forms
@@ -174,7 +174,7 @@ class AdminController extends Controller
 
         // set the ApiMapping object based on whether it's new or existing one
         if ($request->request->get('api_mapping')['id']) {
-            $apiMapping = $em->getRepository('DevlabsSportifyBundle:ApiMapping')
+            $apiMapping = $em->getRepository(ApiMapping::class)
                 ->findOneById($request->request->get('api_mapping')['id']);
         } else {
             $apiMapping = new ApiMapping();
@@ -212,7 +212,7 @@ class AdminController extends Controller
         $adminHelper = $this->container->get('app.admin.helper');
 
         // get all tournaments
-        $tournaments = $em->getRepository('DevlabsSportifyBundle:Tournament')
+        $tournaments = $em->getRepository(Tournament::class)
             ->findAll();
 
         // add an 'empty' placeholder for a new tournament to be created
@@ -254,7 +254,7 @@ class AdminController extends Controller
 
         // set the tournament object based on whether it's new or existing one
         if ($request->request->get('tournament_entity')['id']) {
-            $tournament = $em->getRepository('DevlabsSportifyBundle:Tournament')
+            $tournament = $em->getRepository(Tournament::class)
                 ->findOneById($request->request->get('tournament_entity')['id']);
         } else {
             $tournament = new Tournament();
@@ -296,7 +296,7 @@ class AdminController extends Controller
         $adminHelper = $this->container->get('app.admin.helper');
 
         // get all teams
-        $teams = $em->getRepository('DevlabsSportifyBundle:Team')
+        $teams = $em->getRepository(Team::class)
             ->findAll();
 
         // add an 'empty' placeholder for a new team to be created
@@ -338,7 +338,7 @@ class AdminController extends Controller
 
         // set the team object based on whether it's new or existing one
         if ($request->request->get('team_entity')['id']) {
-            $team = $em->getRepository('DevlabsSportifyBundle:Team')
+            $team = $em->getRepository(Team::class)
                 ->findOneById($request->request->get('team_entity')['id']);
         } else {
             $team = new Team();
@@ -382,13 +382,13 @@ class AdminController extends Controller
          */
         if ($tournament_id === 'empty') {
             $formSourceData['tournament_selected'] = ($request->cookies->has('tournament'))
-                ? $em->getRepository('DevlabsSportifyBundle:Tournament')
+                ? $em->getRepository(Tournament::class)
                     ->findOneById($request->cookies->get('tournament'))
-                : $em->getRepository('DevlabsSportifyBundle:Tournament')
+                : $em->getRepository(Tournament::class)
                     ->getFirst();
             $urlParams['tournament_id'] = $formSourceData['tournament_selected']->getId();
         } else {
-            $formSourceData['tournament_selected'] = $em->getRepository('DevlabsSportifyBundle:Tournament')
+            $formSourceData['tournament_selected'] = $em->getRepository(Tournament::class)
                 ->findOneById($tournament_id);
         }
 
@@ -397,12 +397,12 @@ class AdminController extends Controller
          * (usually happens when invalid 'tournament id' is passed)
          */
         if (!$formSourceData['tournament_selected']) {
-            $formSourceData['tournament_selected'] = $em->getRepository('DevlabsSportifyBundle:Tournament')
+            $formSourceData['tournament_selected'] = $em->getRepository(Tournament::class)
                 ->getFirst();
         }
 
         // get all tournaments as source data for form choices
-        $formSourceData['tournament_choices'] = $em->getRepository('DevlabsSportifyBundle:Tournament')
+        $formSourceData['tournament_choices'] = $em->getRepository(Tournament::class)
             ->findAll();
 
         // get the filter helper service
@@ -424,7 +424,7 @@ class AdminController extends Controller
         }
 
         // get matches for selected tournament
-        $matches = $em->getRepository('DevlabsSportifyBundle:Match')
+        $matches = $em->getRepository(Match::class)
             ->getAllByTournamentAndTimeRange($formSourceData['tournament_selected'], $urlParams['date_from'], $modifiedDateTo);
 
         // add an 'empty' placeholder for a new match to be created
@@ -468,12 +468,12 @@ class AdminController extends Controller
 
         $urlParams = $adminHelper->MatchesInitUrlParams($tournament_id, $date_from, $date_to);
 
-        $tournament = $em->getRepository('DevlabsSportifyBundle:Tournament')
+        $tournament = $em->getRepository(Tournament::class)
             ->findOneById($tournament_id);
 
         // set the match object based on whether it's new or existing one
         if ($request->request->get('match_entity')['id']) {
-            $match = $em->getRepository('DevlabsSportifyBundle:Match')
+            $match = $em->getRepository(Match::class)
                 ->findOneById($request->request->get('match_entity')['id']);
         } else {
             $match = new Match();
@@ -481,9 +481,9 @@ class AdminController extends Controller
         }
 
         // prep data for use in Match object setter methods
-        $homeTeam = $em->getRepository('DevlabsSportifyBundle:Team')
+        $homeTeam = $em->getRepository(Team::class)
             ->findOneById($request->request->get('match_entity')['homeTeamId']['id']);
-        $awayTeam = $em->getRepository('DevlabsSportifyBundle:Team')
+        $awayTeam = $em->getRepository(Team::class)
             ->findOneById($request->request->get('match_entity')['awayTeamId']['id']);
         $datetime = \DateTime::createFromFormat('Y-m-d H:i', $request->request->get('match_entity')['datetime']);
         $notificationSent = (array_key_exists('notificationSent', $request->request->get('match_entity')))

--- a/src/Devlabs/SportifyBundle/Controller/Api/Champ_predictionController.php
+++ b/src/Devlabs/SportifyBundle/Controller/Api/Champ_predictionController.php
@@ -13,6 +13,6 @@ class Champ_predictionController extends BaseApiController
 {
     protected $entityName = 'PredictionChampion';
     protected $fqEntityClass = PredictionChampion::class;
-    protected $repositoryName = 'DevlabsSportifyBundle:PredictionChampion';
+    protected $repositoryName = PredictionChampion::class;
     protected $fqEntityFormClass = PredictionChampionEntityType::class;
 }

--- a/src/Devlabs/SportifyBundle/Controller/Api/MatchController.php
+++ b/src/Devlabs/SportifyBundle/Controller/Api/MatchController.php
@@ -4,6 +4,7 @@ namespace Devlabs\SportifyBundle\Controller\Api;
 
 use Devlabs\SportifyBundle\Controller\Base\BaseApiController;
 use Devlabs\SportifyBundle\Entity\Match;
+use Devlabs\SportifyBundle\Entity\Prediction;
 use Devlabs\SportifyBundle\Form\MatchEntityType;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
 
@@ -15,7 +16,7 @@ class MatchController extends BaseApiController
 {
     protected $entityName = 'Match';
     protected $fqEntityClass = Match::class;
-    protected $repositoryName = 'DevlabsSportifyBundle:Match';
+    protected $repositoryName = Match::class;
     protected $fqEntityFormClass = MatchEntityType::class;
 
     /**
@@ -72,7 +73,7 @@ class MatchController extends BaseApiController
         }
 
         $prediction = $this->getDoctrine()->getManager()
-            ->getRepository('DevlabsSportifyBundle:Prediction')
+            ->getRepository(Prediction::class)
             ->findOneBy(array(
                 'matchId' => $id,
                 'userId' => $user->getId()

--- a/src/Devlabs/SportifyBundle/Controller/Api/PredictionController.php
+++ b/src/Devlabs/SportifyBundle/Controller/Api/PredictionController.php
@@ -17,7 +17,7 @@ class PredictionController extends BaseApiController
 {
     protected $entityName = 'Prediction';
     protected $fqEntityClass = Prediction::class;
-    protected $repositoryName = 'DevlabsSportifyBundle:Prediction';
+    protected $repositoryName = Prediction::class;
     protected $fqEntityFormClass = PredictionType::class;
 
     /**

--- a/src/Devlabs/SportifyBundle/Controller/Api/ScoreController.php
+++ b/src/Devlabs/SportifyBundle/Controller/Api/ScoreController.php
@@ -13,6 +13,6 @@ class ScoreController extends BaseApiController
 {
     protected $entityName = 'Score';
     protected $fqEntityClass = Score::class;
-    protected $repositoryName = 'DevlabsSportifyBundle:Score';
+    protected $repositoryName = Score::class;
     protected $fqEntityFormClass = ScoreEntityType::class;
 }

--- a/src/Devlabs/SportifyBundle/Controller/Api/TeamController.php
+++ b/src/Devlabs/SportifyBundle/Controller/Api/TeamController.php
@@ -15,7 +15,7 @@ class TeamController extends BaseApiController
 {
     protected $entityName = 'Team';
     protected $fqEntityClass = Team::class;
-    protected $repositoryName = 'DevlabsSportifyBundle:Team';
+    protected $repositoryName = Team::class;
     protected $fqEntityFormClass = TeamEntityType::class;
 
     /**

--- a/src/Devlabs/SportifyBundle/Controller/Api/TournamentController.php
+++ b/src/Devlabs/SportifyBundle/Controller/Api/TournamentController.php
@@ -3,6 +3,7 @@
 namespace Devlabs\SportifyBundle\Controller\Api;
 
 use Devlabs\SportifyBundle\Controller\Base\BaseApiController;
+use Devlabs\SportifyBundle\Entity\Score;
 use Devlabs\SportifyBundle\Entity\Tournament;
 use Devlabs\SportifyBundle\Form\TournamentEntityType;
 use Nelmio\ApiDocBundle\Annotation\ApiDoc;
@@ -15,7 +16,7 @@ class TournamentController extends BaseApiController
 {
     protected $entityName = 'Tournament';
     protected $fqEntityClass = Tournament::class;
-    protected $repositoryName = 'DevlabsSportifyBundle:Tournament';
+    protected $repositoryName = Tournament::class;
     protected $fqEntityFormClass = TournamentEntityType::class;
 
     /**
@@ -44,7 +45,7 @@ class TournamentController extends BaseApiController
         }
 
         $scores = $this->getDoctrine()->getManager()
-            ->getRepository('DevlabsSportifyBundle:Score')
+            ->getRepository(Score::class)
             ->getByTournamentOrderByPosNew($tournament);
 
         return $this->view($scores, 200);

--- a/src/Devlabs/SportifyBundle/Controller/Api/UserController.php
+++ b/src/Devlabs/SportifyBundle/Controller/Api/UserController.php
@@ -16,7 +16,7 @@ class UserController extends BaseApiController
 {
     protected $entityName = 'User';
     protected $fqEntityClass = User::class;
-    protected $repositoryName = 'DevlabsSportifyBundle:User';
+    protected $repositoryName = User::class;
     protected $fqEntityFormClass = UserType::class;
 
     /**

--- a/src/Devlabs/SportifyBundle/Controller/Base/BaseApiController.php
+++ b/src/Devlabs/SportifyBundle/Controller/Base/BaseApiController.php
@@ -25,7 +25,7 @@ abstract class BaseApiController extends FOSRestController implements ClassResou
     protected $fqEntityClass;
 
     /**
-     * The repository for the model, e.g. 'DevlabsSportifyBundle:Model'
+     * The repository for the model, e.g. Model::class
      */
     protected $repositoryName;
 

--- a/src/Devlabs/SportifyBundle/Controller/ChampionController.php
+++ b/src/Devlabs/SportifyBundle/Controller/ChampionController.php
@@ -2,6 +2,9 @@
 
 namespace Devlabs\SportifyBundle\Controller;
 
+use Devlabs\SportifyBundle\Entity\PredictionChampion;
+use Devlabs\SportifyBundle\Entity\Score;
+use Devlabs\SportifyBundle\Entity\Tournament;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -24,13 +27,13 @@ class ChampionController extends Controller
         $em = $this->getDoctrine()->getManager();
 
         // get user joined tournaments as source data for form choices
-        $formSourceData['tournament_choices'] = $em->getRepository('DevlabsSportifyBundle:Tournament')
+        $formSourceData['tournament_choices'] = $em->getRepository(Tournament::class)
             ->getJoined($user);
 
         // get informational message if user has not joined any tournaments
         if (!$formSourceData['tournament_choices']) {
             // get the user's tournaments position data
-            $userScores = $em->getRepository('DevlabsSportifyBundle:Score')
+            $userScores = $em->getRepository(Score::class)
                 ->getByUser($user);
             $this->container->get('twig')->addGlobal('user_scores', $userScores);
 
@@ -43,7 +46,7 @@ class ChampionController extends Controller
          */
         $formSourceData['tournament_selected'] = ($tournament_id === 'empty')
             ? $formSourceData['tournament_choices'][0]
-            : $em->getRepository('DevlabsSportifyBundle:Tournament')->findOneById($tournament_id);
+            : $em->getRepository(Tournament::class)->findOneById($tournament_id);
 
         // get the filter helper service
         $filterHelper = $this->container->get('app.filter.helper');
@@ -96,7 +99,7 @@ class ChampionController extends Controller
         }
 
         // get a list of all users Champion predictions for the selected tournament
-        $championPredictions = $em->getRepository('DevlabsSportifyBundle:PredictionChampion')
+        $championPredictions = $em->getRepository(PredictionChampion::class)
             ->findByTournamentId($formSourceData['tournament_selected']);
 
         // get user standings and set them as global Twig var

--- a/src/Devlabs/SportifyBundle/Controller/HistoryController.php
+++ b/src/Devlabs/SportifyBundle/Controller/HistoryController.php
@@ -2,6 +2,8 @@
 
 namespace Devlabs\SportifyBundle\Controller;
 
+use Devlabs\SportifyBundle\Entity\Match;
+use Devlabs\SportifyBundle\Entity\Prediction;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -50,9 +52,9 @@ class HistoryController extends Controller
         }
 
         // get finished scored matches and the user's predictions for them
-        $matches = $em->getRepository('DevlabsSportifyBundle:Match')
+        $matches = $em->getRepository(Match::class)
             ->getAlreadyScored($formSourceData['user_selected'], $urlParams['tournament_id'], $urlParams['date_from'], $modifiedDateTo);
-        $predictions = $em->getRepository('DevlabsSportifyBundle:Prediction')
+        $predictions = $em->getRepository(Prediction::class)
             ->getAlreadyScored($formSourceData['user_selected'], $urlParams['tournament_id'], $urlParams['date_from'], $modifiedDateTo);
 
         // get user standings and set them as global Twig var

--- a/src/Devlabs/SportifyBundle/Controller/MatchesController.php
+++ b/src/Devlabs/SportifyBundle/Controller/MatchesController.php
@@ -2,6 +2,7 @@
 
 namespace Devlabs\SportifyBundle\Controller;
 
+use Devlabs\SportifyBundle\Entity\Match;
 use Devlabs\SportifyBundle\Entity\Prediction;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
@@ -50,9 +51,9 @@ class MatchesController extends Controller
         }
 
         // get not finished matches and the user's predictions for them
-        $matches = $em->getRepository('DevlabsSportifyBundle:Match')
+        $matches = $em->getRepository(Match::class)
             ->getNotScored($user, $urlParams['tournament_id'], $urlParams['date_from'], $modifiedDateTo);
-        $predictions = $em->getRepository('DevlabsSportifyBundle:Prediction')
+        $predictions = $em->getRepository(Prediction::class)
             ->getNotScored($user, $urlParams['tournament_id'], $urlParams['date_from'], $modifiedDateTo);
 
         $matchForms = array();
@@ -98,12 +99,12 @@ class MatchesController extends Controller
         $em = $this->getDoctrine()->getManager();
 
         // get the submitted form's match object
-        $match = $em->getRepository('DevlabsSportifyBundle:Match')
+        $match = $em->getRepository(Match::class)
             ->findOneById($request->request->get('prediction')['matchId']);
 
         // set the prediction object based on whether it's new or existing one
         if ($request->request->get('prediction')['id']) {
-            $prediction = $em->getRepository('DevlabsSportifyBundle:Prediction')
+            $prediction = $em->getRepository(Prediction::class)
                 ->findOneById($request->request->get('prediction')['id']);
             $prediction->setHomeGoals($request->request->get('prediction')['homeGoals']);
             $prediction->setAwayGoals($request->request->get('prediction')['awayGoals']);
@@ -149,7 +150,7 @@ class MatchesController extends Controller
         $formsArray = $request->request->get('matches');
 
         foreach ($formsArray as $submittedForm) {
-            $match = $em->getRepository('DevlabsSportifyBundle:Match')
+            $match = $em->getRepository(Match::class)
                 ->findOneById($submittedForm['matchId']);
 
             // skip to next form if this match has started or data is invalid
@@ -166,7 +167,7 @@ class MatchesController extends Controller
                 $prediction->setHomeGoals($submittedForm['homeGoals']);
                 $prediction->setAwayGoals($submittedForm['awayGoals']);
             } elseif ($submittedForm['action'] === 'EDIT') {
-                $prediction = $em->getRepository('DevlabsSportifyBundle:Prediction')
+                $prediction = $em->getRepository(Prediction::class)
                     ->getOneByUserAndMatch($user, $match);
                 $prediction->setHomeGoals($submittedForm['homeGoals']);
                 $prediction->setAwayGoals($submittedForm['awayGoals']);

--- a/src/Devlabs/SportifyBundle/Controller/StandingsController.php
+++ b/src/Devlabs/SportifyBundle/Controller/StandingsController.php
@@ -2,6 +2,8 @@
 
 namespace Devlabs\SportifyBundle\Controller;
 
+use Devlabs\SportifyBundle\Entity\Score;
+use Devlabs\SportifyBundle\Entity\Tournament;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -27,12 +29,12 @@ class StandingsController extends Controller
          */
         if ($tournament_id === 'empty') {
             $formSourceData['tournament_selected'] = ($request->cookies->has('tournament'))
-                ? $em->getRepository('DevlabsSportifyBundle:Tournament')
+                ? $em->getRepository(Tournament::class)
                     ->findOneById($request->cookies->get('tournament'))
-                : $em->getRepository('DevlabsSportifyBundle:Tournament')
+                : $em->getRepository(Tournament::class)
                     ->getFirst();
         } else {
-            $formSourceData['tournament_selected'] = $em->getRepository('DevlabsSportifyBundle:Tournament')
+            $formSourceData['tournament_selected'] = $em->getRepository(Tournament::class)
                 ->findOneById($tournament_id);
         }
 
@@ -41,12 +43,12 @@ class StandingsController extends Controller
          * (usually happens when invalid 'tournament id' is passed)
          */
         if (!$formSourceData['tournament_selected']) {
-            $formSourceData['tournament_selected'] = $em->getRepository('DevlabsSportifyBundle:Tournament')
+            $formSourceData['tournament_selected'] = $em->getRepository(Tournament::class)
                 ->getFirst();
         }
 
         // get all tournaments as source data for form choices
-        $formSourceData['tournament_choices'] = $em->getRepository('DevlabsSportifyBundle:Tournament')
+        $formSourceData['tournament_choices'] = $em->getRepository(Tournament::class)
             ->findAll();
 
         // get the filter helper service
@@ -73,7 +75,7 @@ class StandingsController extends Controller
 
         if ($formSourceData['tournament_selected']) {
             // get scores standings for a given tournament
-            $allScores = $em->getRepository('DevlabsSportifyBundle:Score')
+            $allScores = $em->getRepository(Score::class)
                 ->getByTournamentOrderByPosNew($formSourceData['tournament_selected']);
 
             // set cookie for tournament selected with 90-day expire period
@@ -114,12 +116,12 @@ class StandingsController extends Controller
          */
         if ($tournament_id === 'empty') {
             $formSourceData['tournament_selected'] = ($request->cookies->has('tournament'))
-                ? $em->getRepository('DevlabsSportifyBundle:Tournament')
+                ? $em->getRepository(Tournament::class)
                     ->findOneById($request->cookies->get('tournament'))
-                : $em->getRepository('DevlabsSportifyBundle:Tournament')
+                : $em->getRepository(Tournament::class)
                     ->getFirst();
         } else {
-            $formSourceData['tournament_selected'] = $em->getRepository('DevlabsSportifyBundle:Tournament')
+            $formSourceData['tournament_selected'] = $em->getRepository(Tournament::class)
                 ->findOneById($tournament_id);
         }
 
@@ -128,12 +130,12 @@ class StandingsController extends Controller
          * (usually happens when invalid 'tournament id' is passed)
          */
         if (!$formSourceData['tournament_selected']) {
-            $formSourceData['tournament_selected'] = $em->getRepository('DevlabsSportifyBundle:Tournament')
+            $formSourceData['tournament_selected'] = $em->getRepository(Tournament::class)
                 ->getFirst();
         }
 
         // get all tournaments as source data for form choices
-        $formSourceData['tournament_choices'] = $em->getRepository('DevlabsSportifyBundle:Tournament')
+        $formSourceData['tournament_choices'] = $em->getRepository(Tournament::class)
             ->findAll();
 
         // get the filter helper service
@@ -160,7 +162,7 @@ class StandingsController extends Controller
 
         if ($formSourceData['tournament_selected']) {
             // get scores standings for a given tournament
-            $allScores = $em->getRepository('DevlabsSportifyBundle:Score')
+            $allScores = $em->getRepository(Score::class)
                 ->getByTournamentOrderByPosNew($formSourceData['tournament_selected']);
 
             // set cookie for tournament selected with 90-day expire period

--- a/src/Devlabs/SportifyBundle/Controller/TournamentsController.php
+++ b/src/Devlabs/SportifyBundle/Controller/TournamentsController.php
@@ -3,6 +3,7 @@
 namespace Devlabs\SportifyBundle\Controller;
 
 use Devlabs\SportifyBundle\Entity\Score;
+use Devlabs\SportifyBundle\Entity\Tournament;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -28,9 +29,9 @@ class TournamentsController extends Controller
         $tournamentsHelper = $this->container->get('app.tournaments.helper');
 
         // get all and joined tournaments lists
-        $tournaments = $em->getRepository('DevlabsSportifyBundle:Tournament')
+        $tournaments = $em->getRepository(Tournament::class)
             ->findAll();
-        $tournamentsJoined = $em->getRepository('DevlabsSportifyBundle:Tournament')
+        $tournamentsJoined = $em->getRepository(Tournament::class)
             ->getJoined($user);
 
         $forms = array();

--- a/src/Devlabs/SportifyBundle/Controller/UserController.php
+++ b/src/Devlabs/SportifyBundle/Controller/UserController.php
@@ -2,6 +2,7 @@
 
 namespace Devlabs\SportifyBundle\Controller;
 
+use Devlabs\SportifyBundle\Entity\OAuthAccessToken;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Devlabs\SportifyBundle\Form\UserType;
@@ -58,7 +59,7 @@ class UserController extends Controller
         }
 
         $accessToken = $this->getDoctrine()->getManager()
-            ->getRepository('DevlabsSportifyBundle:OAuthAccessToken')
+            ->getRepository(OAuthAccessToken::class)
             ->getLastNotExpired($user);
 
         $formData = array();

--- a/src/Devlabs/SportifyBundle/Entity/ApiMappingRepository.php
+++ b/src/Devlabs/SportifyBundle/Entity/ApiMappingRepository.php
@@ -22,7 +22,7 @@ class ApiMappingRepository extends \Doctrine\ORM\EntityRepository
     {
         $query =  $this->getEntityManager()->createQueryBuilder()
             ->select('am')
-            ->from('DevlabsSportifyBundle:ApiMapping', 'am')
+            ->from(ApiMapping::class, 'am')
             ->where('am.entityType = :entity_type')
             ->andWhere('am.apiName = :api_name')
             ->andWhere('am.apiObjectId = :api_object_id')
@@ -54,7 +54,7 @@ class ApiMappingRepository extends \Doctrine\ORM\EntityRepository
     {
         $query =  $this->getEntityManager()->createQueryBuilder()
             ->select('am')
-            ->from('DevlabsSportifyBundle:ApiMapping', 'am')
+            ->from(ApiMapping::class, 'am')
             ->where('am.entityId = :entity_id')
             ->andWhere('am.entityType = :entity_type')
             ->andWhere('am.apiName = :api_name')

--- a/src/Devlabs/SportifyBundle/Entity/MatchRepository.php
+++ b/src/Devlabs/SportifyBundle/Entity/MatchRepository.php
@@ -21,7 +21,7 @@ class MatchRepository extends \Doctrine\ORM\EntityRepository
     {
         $query = $this->getEntityManager()->createQueryBuilder()
             ->select('m')
-            ->from('DevlabsSportifyBundle:Match', 'm')
+            ->from(Match::class, 'm')
             ->join('m.homeTeamId', 'tm')
             ->join('m.tournamentId', 't')
             ->join('t.scores', 's', 'WITH', 's.userId = :user_id')
@@ -60,7 +60,7 @@ class MatchRepository extends \Doctrine\ORM\EntityRepository
     {
         $query = $this->getEntityManager()->createQueryBuilder()
             ->select('m')
-            ->from('DevlabsSportifyBundle:Match', 'm')
+            ->from(Match::class, 'm')
             ->join('m.homeTeamId', 'tm')
             ->join('m.tournamentId', 't')
             ->join('t.scores', 's', 'WITH', 's.userId = :user_id')
@@ -96,7 +96,7 @@ class MatchRepository extends \Doctrine\ORM\EntityRepository
     {
         $queryResult = $this->getEntityManager()->createQueryBuilder()
             ->select('DISTINCT m')
-            ->from('DevlabsSportifyBundle:Match', 'm')
+            ->from(Match::class, 'm')
             ->join('m.predictions', 'p')
             ->where('p.scoreAdded IS NULL OR p.scoreAdded = 0')
             ->andWhere('m.homeGoals IS NOT NULL AND m.awayGoals IS NOT NULL')
@@ -127,7 +127,7 @@ class MatchRepository extends \Doctrine\ORM\EntityRepository
     {
         return $this->getEntityManager()->createQueryBuilder()
             ->select('DISTINCT m')
-            ->from('DevlabsSportifyBundle:Match', 'm')
+            ->from(Match::class, 'm')
             ->where('m.homeGoals IS NOT NULL AND m.awayGoals IS NOT NULL')
             ->andWhere('m.tournamentId = :tournament_id')
             ->setParameter('tournament_id', $tournament->getId())
@@ -147,7 +147,7 @@ class MatchRepository extends \Doctrine\ORM\EntityRepository
     {
         return $this->getEntityManager()->createQueryBuilder()
             ->select('m')
-            ->from('DevlabsSportifyBundle:Match', 'm')
+            ->from(Match::class, 'm')
             ->join('m.homeTeamId', 'tm')
             ->where('m.notificationSent = 0')
             ->andWhere('m.datetime >= :date_from AND m.datetime <= :date_to')
@@ -171,7 +171,7 @@ class MatchRepository extends \Doctrine\ORM\EntityRepository
     {
         return $this->getEntityManager()->createQueryBuilder()
             ->select('m')
-            ->from('DevlabsSportifyBundle:Match', 'm')
+            ->from(Match::class, 'm')
             ->join('m.homeTeamId', 'tm')
             ->where('m.tournamentId = :tournament_id')
             ->setParameter('tournament_id', $tournament->getId())
@@ -193,7 +193,7 @@ class MatchRepository extends \Doctrine\ORM\EntityRepository
     {
         return $this->getEntityManager()->createQueryBuilder()
             ->select('m')
-            ->from('DevlabsSportifyBundle:Match', 'm')
+            ->from(Match::class, 'm')
             ->join('m.homeTeamId', 'tm')
             ->where('m.tournamentId = :tournament_id')
             ->andWhere('m.datetime >= :date_from AND m.datetime <= :date_to')
@@ -219,7 +219,7 @@ class MatchRepository extends \Doctrine\ORM\EntityRepository
     {
         $query = $this->getEntityManager()->createQueryBuilder()
             ->select('m')
-            ->from('DevlabsSportifyBundle:Match', 'm')
+            ->from(Match::class, 'm')
             ->join('m.homeTeamId', 'h_tm')
             ->join('m.awayTeamId', 'a_tm')
             ->join('m.tournamentId', 't')

--- a/src/Devlabs/SportifyBundle/Entity/OAuthAccessTokenRepository.php
+++ b/src/Devlabs/SportifyBundle/Entity/OAuthAccessTokenRepository.php
@@ -18,7 +18,7 @@ class OAuthAccessTokenRepository extends \Doctrine\ORM\EntityRepository
     {
         return $this->getEntityManager()->createQueryBuilder()
             ->select('at')
-            ->from('DevlabsSportifyBundle:OAuthAccessToken', 'at')
+            ->from(OAuthAccessToken::class, 'at')
             ->where('at.user = :user_id')
             ->andWhere('at.expiresAt > :current_timestamp')
             ->orderBy('at.expiresAt', 'DESC')

--- a/src/Devlabs/SportifyBundle/Entity/PredictionChampionRepository.php
+++ b/src/Devlabs/SportifyBundle/Entity/PredictionChampionRepository.php
@@ -22,7 +22,7 @@ class PredictionChampionRepository extends \Doctrine\ORM\EntityRepository
     {
         $query = $this->getEntityManager()->createQueryBuilder()
             ->select('p')
-            ->from('DevlabsSportifyBundle:PredictionChampion', 'p')
+            ->from(PredictionChampion::class, 'p')
             ->where('p.userId = :user_id')
             ->andWhere('p.tournamentId = :tournament_id')
             ->setParameters(array(
@@ -48,7 +48,7 @@ class PredictionChampionRepository extends \Doctrine\ORM\EntityRepository
     {
         return $this->getEntityManager()->createQueryBuilder()
             ->select('p')
-            ->from('DevlabsSportifyBundle:PredictionChampion', 'p')
+            ->from(PredictionChampion::class, 'p')
             ->where('p.scoreAdded IS NULL OR p.scoreAdded = 0')
             ->andWhere('p.tournamentId = :tournament_id')
             ->setParameters(array('tournament_id' => $tournament->getId()))

--- a/src/Devlabs/SportifyBundle/Entity/PredictionRepository.php
+++ b/src/Devlabs/SportifyBundle/Entity/PredictionRepository.php
@@ -18,7 +18,7 @@ class PredictionRepository extends \Doctrine\ORM\EntityRepository
     {
         $query = $this->getEntityManager()->createQueryBuilder()
             ->select('p')
-            ->from('DevlabsSportifyBundle:Prediction', 'p')
+            ->from(Prediction::class, 'p')
             ->join('p.matchId', 'm')
             ->join('m.homeTeamId', 'tm')
             ->join('m.tournamentId', 't')
@@ -70,7 +70,7 @@ class PredictionRepository extends \Doctrine\ORM\EntityRepository
     {
         $query = $this->getEntityManager()->createQueryBuilder()
             ->select('p')
-            ->from('DevlabsSportifyBundle:Prediction', 'p')
+            ->from(Prediction::class, 'p')
             ->join('p.matchId', 'm')
             ->join('m.homeTeamId', 'tm')
             ->join('m.tournamentId', 't')
@@ -119,7 +119,7 @@ class PredictionRepository extends \Doctrine\ORM\EntityRepository
     {
         $queryResult = $this->getEntityManager()->createQueryBuilder()
             ->select('p')
-            ->from('DevlabsSportifyBundle:Prediction', 'p')
+            ->from(Prediction::class, 'p')
             ->join('p.matchId', 'm')
             ->where('p.scoreAdded IS NULL OR p.scoreAdded = 0')
             ->andWhere('m.homeGoals IS NOT NULL AND m.awayGoals IS NOT NULL')
@@ -155,7 +155,7 @@ class PredictionRepository extends \Doctrine\ORM\EntityRepository
     {
         return $this->getEntityManager()->createQueryBuilder()
             ->select('p')
-            ->from('DevlabsSportifyBundle:Prediction', 'p')
+            ->from(Prediction::class, 'p')
             ->where('p.userId = :user_id')
             ->andWhere('p.matchId = :match_id')
             ->setParameters(array('user_id' => $user->getId(), 'match_id' => $match->getId()))
@@ -174,7 +174,7 @@ class PredictionRepository extends \Doctrine\ORM\EntityRepository
     {
         return $this->getEntityManager()->createQueryBuilder()
             ->select('p')
-            ->from('DevlabsSportifyBundle:Prediction', 'p')
+            ->from(Prediction::class, 'p')
             ->join('p.matchId', 'm')
             ->where('p.userId = :user_id')
             ->andWhere('p.scoreAdded = 1 AND p.points = :points_exact')
@@ -200,7 +200,7 @@ class PredictionRepository extends \Doctrine\ORM\EntityRepository
     {
         $query = $this->getEntityManager()->createQueryBuilder()
             ->select('p')
-            ->from('DevlabsSportifyBundle:Prediction', 'p')
+            ->from(Prediction::class, 'p')
             ->join('p.matchId', 'm')
             ->join('m.homeTeamId', 'h_tm')
             ->join('m.awayTeamId', 'a_tm')

--- a/src/Devlabs/SportifyBundle/Entity/ScoreRepository.php
+++ b/src/Devlabs/SportifyBundle/Entity/ScoreRepository.php
@@ -21,7 +21,7 @@ class ScoreRepository extends \Doctrine\ORM\EntityRepository
     {
         return $this->getEntityManager()->createQueryBuilder()
             ->select('s')
-            ->from('DevlabsSportifyBundle:Score', 's')
+            ->from(Score::class, 's')
             ->where('s.userId = :user_id')
             ->andWhere('s.tournamentId = :tournament_id')
             ->setParameters(array('user_id' => $user->getId(), 'tournament_id' => $tournament->getId()))
@@ -40,7 +40,7 @@ class ScoreRepository extends \Doctrine\ORM\EntityRepository
     {
         return $this->getEntityManager()->createQueryBuilder()
             ->select('s')
-            ->from('DevlabsSportifyBundle:Score', 's')
+            ->from(Score::class, 's')
             ->join('s.userId', 'u')
             ->where('s.tournamentId = :tournament_id')
             ->orderBy('s.points', 'DESC')
@@ -62,7 +62,7 @@ class ScoreRepository extends \Doctrine\ORM\EntityRepository
     {
         return $this->getEntityManager()->createQueryBuilder()
             ->select('s')
-            ->from('DevlabsSportifyBundle:Score', 's')
+            ->from(Score::class, 's')
             ->where('s.tournamentId = :tournament_id')
             ->orderBy('s.posNew', 'ASC')
             ->setParameters(array('tournament_id' => $tournament->getId()))
@@ -80,7 +80,7 @@ class ScoreRepository extends \Doctrine\ORM\EntityRepository
     {
         $queryResult = $this->getEntityManager()->createQueryBuilder()
             ->select('s')
-            ->from('DevlabsSportifyBundle:Score', 's')
+            ->from(Score::class, 's')
             ->where('s.userId = :user_id')
             ->setParameters(array('user_id' => $user->getId()))
             ->getQuery()
@@ -108,7 +108,7 @@ class ScoreRepository extends \Doctrine\ORM\EntityRepository
     {
         $queryResult = $this->getEntityManager()->createQueryBuilder()
             ->select('s')
-            ->from('DevlabsSportifyBundle:Score', 's')
+            ->from(Score::class, 's')
             ->orderBy('s.posNew', 'ASC')
             ->getQuery()
             ->getResult();

--- a/src/Devlabs/SportifyBundle/Entity/TeamRepository.php
+++ b/src/Devlabs/SportifyBundle/Entity/TeamRepository.php
@@ -22,7 +22,7 @@ class TeamRepository extends \Doctrine\ORM\EntityRepository
     {
         return $this->getEntityManager()->createQueryBuilder()
             ->select('tm')
-            ->from('DevlabsSportifyBundle:Team', 'tm')
+            ->from(Team::class, 'tm')
             ->join('tm.tournaments', 'tr')
             ->where('tr.id = :tournament_id')
             ->setParameters(array(
@@ -43,7 +43,7 @@ class TeamRepository extends \Doctrine\ORM\EntityRepository
     {
         return $this->getEntityManager()->createQueryBuilder()
             ->select('tm')
-            ->from('DevlabsSportifyBundle:Team', 'tm')
+            ->from(Team::class, 'tm')
             ->join('tm.tournaments', 'tr')
             ->where('tr.id = :tournament_id')
             ->setParameters(array(

--- a/src/Devlabs/SportifyBundle/Entity/TournamentRepository.php
+++ b/src/Devlabs/SportifyBundle/Entity/TournamentRepository.php
@@ -18,7 +18,7 @@ class TournamentRepository extends \Doctrine\ORM\EntityRepository
     {
         return $this->getEntityManager()->createQueryBuilder()
             ->select('t')
-            ->from('DevlabsSportifyBundle:Tournament', 't')
+            ->from(Tournament::class, 't')
             ->join('t.scores', 's')
             ->where('s.userId = :user_id')
             ->setParameters(array('user_id' => $user->getId()))
@@ -37,7 +37,7 @@ class TournamentRepository extends \Doctrine\ORM\EntityRepository
     {
         $query = $this->getEntityManager()->createQueryBuilder()
             ->select('t')
-            ->from('DevlabsSportifyBundle:Tournament', 't')
+            ->from(Tournament::class, 't')
             ->setMaxResults(1);
 
         try {

--- a/src/Devlabs/SportifyBundle/Entity/UserRepository.php
+++ b/src/Devlabs/SportifyBundle/Entity/UserRepository.php
@@ -17,7 +17,7 @@ class UserRepository extends \Doctrine\ORM\EntityRepository
     {
         return $this->getEntityManager()->createQueryBuilder()
             ->select('u')
-            ->from('DevlabsSportifyBundle:User', 'u')
+            ->from(User::class, 'u')
             ->where('u.enabled = 1')
             ->orderBy('u.email', 'ASC')
             ->getQuery()
@@ -35,7 +35,7 @@ class UserRepository extends \Doctrine\ORM\EntityRepository
         $qb = $this->getEntityManager()->createQueryBuilder();
         $usersWithPredictions = $qb
             ->select(['u.id'])
-            ->from('DevlabsSportifyBundle:User', 'u')
+            ->from(User::class, 'u')
             ->join('u.predictions', 'p')
             ->where('u.enabled = 1')
             ->andWhere('p.matchId = :match_id')
@@ -50,7 +50,7 @@ class UserRepository extends \Doctrine\ORM\EntityRepository
         if ($usersWithPredictions) {
             return $qb
                 ->select('u')
-                ->from('DevlabsSportifyBundle:User', 'u')
+                ->from(User::class, 'u')
                 ->join('u.scores', 's')
                 ->where('u.enabled = 1')
                 ->andWhere('s.tournamentId = :tournament_id')
@@ -65,7 +65,7 @@ class UserRepository extends \Doctrine\ORM\EntityRepository
         } else {
             return $qb
                 ->select('u')
-                ->from('DevlabsSportifyBundle:User', 'u')
+                ->from(User::class, 'u')
                 ->join('u.scores', 's')
                 ->where('u.enabled = 1')
                 ->andWhere('s.tournamentId = :tournament_id')

--- a/src/Devlabs/SportifyBundle/Form/DataTransformer/MatchToIdTransformer.php
+++ b/src/Devlabs/SportifyBundle/Form/DataTransformer/MatchToIdTransformer.php
@@ -46,7 +46,7 @@ class MatchToIdTransformer implements DataTransformerInterface
         }
 
         $match = $this->manager
-            ->getRepository('DevlabsSportifyBundle:Match')
+            ->getRepository(Match::class)
             // query for the match with this id
             ->find($matchId)
         ;

--- a/src/Devlabs/SportifyBundle/Form/DataTransformer/TeamToIdTransformer.php
+++ b/src/Devlabs/SportifyBundle/Form/DataTransformer/TeamToIdTransformer.php
@@ -46,7 +46,7 @@ class TeamToIdTransformer implements DataTransformerInterface
         }
 
         $team = $this->manager
-            ->getRepository('DevlabsSportifyBundle:Team')
+            ->getRepository(Team::class)
             // query for the team with this id
             ->find($teamId)
         ;

--- a/src/Devlabs/SportifyBundle/Form/DataTransformer/TournamentToIdTransformer.php
+++ b/src/Devlabs/SportifyBundle/Form/DataTransformer/TournamentToIdTransformer.php
@@ -46,7 +46,7 @@ class TournamentToIdTransformer implements DataTransformerInterface
         }
 
         $tournament = $this->manager
-            ->getRepository('DevlabsSportifyBundle:Tournament')
+            ->getRepository(Tournament::class)
             // query for the tournament with this id
             ->find($tournamentId)
         ;

--- a/src/Devlabs/SportifyBundle/Form/DataTransformer/UserToIdTransformer.php
+++ b/src/Devlabs/SportifyBundle/Form/DataTransformer/UserToIdTransformer.php
@@ -46,7 +46,7 @@ class UserToIdTransformer implements DataTransformerInterface
         }
 
         $user = $this->manager
-            ->getRepository('DevlabsSportifyBundle:User')
+            ->getRepository(User::class)
             // query for the user with this id
             ->find($userId)
         ;

--- a/src/Devlabs/SportifyBundle/Form/TeamChoiceType.php
+++ b/src/Devlabs/SportifyBundle/Form/TeamChoiceType.php
@@ -2,6 +2,7 @@
 
 namespace Devlabs\SportifyBundle\Form;
 
+use Devlabs\SportifyBundle\Entity\Team;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -30,7 +31,7 @@ class TeamChoiceType extends AbstractType
 
         $builder
             ->add('id', EntityType::class, array(
-                'class' => 'DevlabsSportifyBundle:Team',
+                'class' => Team::class,
                 'choices' => $this->choices,
                 'choice_label' => 'name',
                 'label' => false,

--- a/src/Devlabs/SportifyBundle/Form/TournamentChoiceType.php
+++ b/src/Devlabs/SportifyBundle/Form/TournamentChoiceType.php
@@ -2,6 +2,7 @@
 
 namespace Devlabs\SportifyBundle\Form;
 
+use Devlabs\SportifyBundle\Entity\Tournament;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -30,7 +31,7 @@ class TournamentChoiceType extends AbstractType
 
         $builder
             ->add('id', EntityType::class, array(
-                'class' => 'DevlabsSportifyBundle:Tournament',
+                'class' => Tournament::class,
                 'choices' => $this->choices,
                 'data' => $this->data,
                 'choice_label' => 'name',

--- a/src/Devlabs/SportifyBundle/Form/UserChoiceType.php
+++ b/src/Devlabs/SportifyBundle/Form/UserChoiceType.php
@@ -2,6 +2,7 @@
 
 namespace Devlabs\SportifyBundle\Form;
 
+use Devlabs\SportifyBundle\Entity\User;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -30,7 +31,7 @@ class UserChoiceType extends AbstractType
 
         $builder
             ->add('id', EntityType::class, array(
-                'class' => 'DevlabsSportifyBundle:User',
+                'class' => User::class,
                 'choices' => $this->choices,
                 'choice_label' => 'username',
                 'label' => false,

--- a/src/Devlabs/SportifyBundle/Services/ControllerHelpers/AdminHelper.php
+++ b/src/Devlabs/SportifyBundle/Services/ControllerHelpers/AdminHelper.php
@@ -105,7 +105,7 @@ class AdminHelper
                 }
             }
         } else if ($data['update_type'] === 'teams-all-tournaments') {
-            $tournaments = $this->em->getRepository('DevlabsSportifyBundle:Tournament')
+            $tournaments = $this->em->getRepository(Tournament::class)
                 ->findAll();
 
             foreach ($tournaments as $tournament) {
@@ -135,7 +135,7 @@ class AdminHelper
     public function getApiMapping(Tournament $tournament, $footballApi)
     {
         // get existing ApiMapping or create new if none exists
-        $apiMapping = $this->em->getRepository('DevlabsSportifyBundle:ApiMapping')
+        $apiMapping = $this->em->getRepository(ApiMapping::class)
             ->getByEntityAndApiProvider($tournament, 'Tournament', $footballApi);
 
         // get a new ApiMapping object if none
@@ -303,7 +303,7 @@ class AdminHelper
             : null;
 
         // get a list of teams for the selected tournament
-        $teamChoices = $this->em->getRepository('DevlabsSportifyBundle:Team')
+        $teamChoices = $this->em->getRepository(Team::class)
             ->getAllByTournament($tournament);
 
         // set the input form-data for the tournament form
@@ -433,13 +433,13 @@ class AdminHelper
 
         $homeTeam = ($match->getHomeTeamId())
             ? $match->getHomeTeamId()
-            : $this->em->getRepository('DevlabsSportifyBundle:Team')->getFirstByTournament($tournament);
+            : $this->em->getRepository(Team::class)->getFirstByTournament($tournament);
         $awayTeam = ($match->getAwayTeamId())
             ? $match->getAwayTeamId()
-            : $this->em->getRepository('DevlabsSportifyBundle:Team')->getFirstByTournament($tournament);
+            : $this->em->getRepository(Team::class)->getFirstByTournament($tournament);
 
         // get a list of teams for the selected tournament
-        $teamChoices = $this->em->getRepository('DevlabsSportifyBundle:Team')
+        $teamChoices = $this->em->getRepository(Team::class)
             ->getAllByTournament($tournament);
 
         // set the input form-data for the match form

--- a/src/Devlabs/SportifyBundle/Services/ControllerHelpers/ChampionHelper.php
+++ b/src/Devlabs/SportifyBundle/Services/ControllerHelpers/ChampionHelper.php
@@ -6,6 +6,7 @@ use Devlabs\SportifyBundle\Entity\Tournament;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Doctrine\ORM\EntityManager;
+use Devlabs\SportifyBundle\Entity\Team;
 use Devlabs\SportifyBundle\Entity\User;
 use Devlabs\SportifyBundle\Entity\PredictionChampion;
 use Symfony\Component\Form\Form;
@@ -37,7 +38,7 @@ class ChampionHelper
     public function getPredictionChampion(User $user, Tournament $tournament)
     {
         // get user's champion prediction or null if there's none
-        $predictionChampion = $this->em->getRepository('DevlabsSportifyBundle:PredictionChampion')
+        $predictionChampion = $this->em->getRepository(PredictionChampion::class)
             ->getByUserAndTournament($user, $tournament);
 
         // get a new PredictionChampion object if none
@@ -61,7 +62,7 @@ class ChampionHelper
 
         // determine if the user has already set a champion prediction
         if (!$predictionChampion->getId()) {
-            $teamSelected = $this->em->getRepository('DevlabsSportifyBundle:Team')
+            $teamSelected = $this->em->getRepository(Team::class)
                 ->getFirstByTournament($tournament);
             $buttonAction = 'BET';
         } else {
@@ -70,7 +71,7 @@ class ChampionHelper
         }
 
         // get a list of teams for the selected tournament
-        $teamChoices = $this->em->getRepository('DevlabsSportifyBundle:Team')
+        $teamChoices = $this->em->getRepository(Team::class)
             ->getAllByTournament($tournament);
 
         // set the input form-data for the champion form

--- a/src/Devlabs/SportifyBundle/Services/ControllerHelpers/TournamentsHelper.php
+++ b/src/Devlabs/SportifyBundle/Services/ControllerHelpers/TournamentsHelper.php
@@ -83,7 +83,7 @@ class TournamentsHelper
     public function actionOnFormSubmit(Form $form, User $user)
     {
         $formData = $form->getData();
-        $tournament = $this->em->getRepository('DevlabsSportifyBundle:Tournament')
+        $tournament = $this->em->getRepository(Tournament::class)
             ->findOneById($formData['id']);
 
         // prepare the queries for tournament join/leave (add/delete row in `scores` table)
@@ -123,7 +123,7 @@ class TournamentsHelper
      */
     public function leaveTournament(User $user, Tournament $tournament)
     {
-        $score = $this->em->getRepository('DevlabsSportifyBundle:Score')
+        $score = $this->em->getRepository(Score::class)
             ->getByUserAndTournament($user, $tournament);
         $this->em->remove($score);
 

--- a/src/Devlabs/SportifyBundle/Services/DataUpdates/Importer.php
+++ b/src/Devlabs/SportifyBundle/Services/DataUpdates/Importer.php
@@ -38,7 +38,7 @@ class Importer
         foreach ($teams as $teamData) {
             $apiObjectId = $teamData['team_id'];
 
-            $apiMapping = $this->em->getRepository('DevlabsSportifyBundle:ApiMapping')
+            $apiMapping = $this->em->getRepository(ApiMapping::class)
                 ->getByEntityTypeAndApiObjectId('Team', $footballApi, $apiObjectId);
 
             if (!$apiMapping) {
@@ -58,7 +58,7 @@ class Importer
                 $this->em->persist($apiMapping);
             } else {
                 // get Team from DB
-                $team = $this->em->getRepository('DevlabsSportifyBundle:Team')
+                $team = $this->em->getRepository(Team::class)
                     ->find($apiMapping->getEntityId());
 
                 // add Tournament to Team's tournaments list if NOT already present
@@ -98,23 +98,23 @@ class Importer
         foreach ($fixtures as $fixtureData) {
             $apiMatchId = $fixtureData['match_id'];
 
-            $matchApiMapping = $this->em->getRepository('DevlabsSportifyBundle:ApiMapping')
+            $matchApiMapping = $this->em->getRepository(ApiMapping::class)
                 ->getByEntityTypeAndApiObjectId('Match', $footballApi, $apiMatchId);
 
             if (!$matchApiMapping) {
                 $apiHomeTeamId = $fixtureData['home_team_id'];
                 $apiAwayTeamId = $fixtureData['away_team_id'];
 
-                $homeTeamId = $this->em->getRepository('DevlabsSportifyBundle:ApiMapping')
+                $homeTeamId = $this->em->getRepository(ApiMapping::class)
                     ->getByEntityTypeAndApiObjectId('Team', $footballApi, $apiHomeTeamId)
                     ->getEntityId();
-                $awayTeamId = $this->em->getRepository('DevlabsSportifyBundle:ApiMapping')
+                $awayTeamId = $this->em->getRepository(ApiMapping::class)
                     ->getByEntityTypeAndApiObjectId('Team', $footballApi, $apiAwayTeamId)
                     ->getEntityId();
 
-                $homeTeam = $this->em->getRepository('DevlabsSportifyBundle:Team')
+                $homeTeam = $this->em->getRepository(Team::class)
                     ->findOneById($homeTeamId);
-                $awayTeam = $this->em->getRepository('DevlabsSportifyBundle:Team')
+                $awayTeam = $this->em->getRepository(Team::class)
                     ->findOneById($awayTeamId);
 
                 $datetime = \DateTime::createFromFormat('Y-m-d H:i:s', $fixtureData['match_local_time']);
@@ -139,7 +139,7 @@ class Importer
 
             } else {
                 // get match from db
-                $match = $this->em->getRepository('DevlabsSportifyBundle:Match')
+                $match = $this->em->getRepository(Match::class)
                     ->findOneById($matchApiMapping->getEntityId());
 
                 $matchUpdated = false;

--- a/src/Devlabs/SportifyBundle/Services/DataUpdates/Manager.php
+++ b/src/Devlabs/SportifyBundle/Services/DataUpdates/Manager.php
@@ -5,6 +5,7 @@ namespace Devlabs\SportifyBundle\Services\DataUpdates;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Doctrine\ORM\EntityManager;
+use Devlabs\SportifyBundle\Entity\ApiMapping;
 use Devlabs\SportifyBundle\Entity\Tournament;
 
 /**
@@ -40,7 +41,7 @@ class Manager
      */
     public function updateTeamsByTournament(Tournament $tournament)
     {
-        $apiMapping = $this->em->getRepository('DevlabsSportifyBundle:ApiMapping')
+        $apiMapping = $this->em->getRepository(ApiMapping::class)
             ->getByEntityAndApiProvider($tournament, 'Tournament', $this->footballApi);
 
         if (!$apiMapping) {
@@ -71,7 +72,7 @@ class Manager
         $status['total_updated'] = 0;
 
         // get all tournaments
-        $tournaments = $this->em->getRepository('DevlabsSportifyBundle:Tournament')->findAll();
+        $tournaments = $this->em->getRepository(Tournament::class)->findAll();
 
         // return if no tournaments in db
         if (!$tournaments) {
@@ -80,7 +81,7 @@ class Manager
 
         // iterate the following actions for each tournament
         foreach ($tournaments as $tournament) {
-            $apiMapping = $this->em->getRepository('DevlabsSportifyBundle:ApiMapping')
+            $apiMapping = $this->em->getRepository(ApiMapping::class)
                 ->getByEntityAndApiProvider($tournament, 'Tournament', $this->footballApi);
 
             // skip tournament if finished or there is no API mapping for it

--- a/src/Devlabs/SportifyBundle/Services/FilterHelper.php
+++ b/src/Devlabs/SportifyBundle/Services/FilterHelper.php
@@ -5,6 +5,8 @@ namespace Devlabs\SportifyBundle\Services;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Doctrine\ORM\EntityManager;
+use Devlabs\SportifyBundle\Entity\Tournament;
+use Devlabs\SportifyBundle\Entity\User;
 use Devlabs\SportifyBundle\Form\FilterType;
 
 /**
@@ -39,20 +41,20 @@ class FilterHelper
             // use the selected tournament as object, based on id URL: {tournament} route parameter
             $formSourceData['tournament_selected'] = ($urlParams['tournament_id'] === 'all')
                 ? null
-                : $this->em->getRepository('DevlabsSportifyBundle:Tournament')->findOneById($urlParams['tournament_id']);
+                : $this->em->getRepository(Tournament::class)->findOneById($urlParams['tournament_id']);
 
             // get user's joined tournaments
-            $formSourceData['tournament_choices'] = $this->em->getRepository('DevlabsSportifyBundle:Tournament')
+            $formSourceData['tournament_choices'] = $this->em->getRepository(Tournament::class)
                 ->getJoined($user);
         }
 
         if (in_array('user', $fields)) {
             // use the selected user as object, based on id URL: {user_id} route parameter
-            $formSourceData['user_selected'] = $this->em->getRepository('DevlabsSportifyBundle:User')
+            $formSourceData['user_selected'] = $this->em->getRepository(User::class)
                 ->findOneById($urlParams['user_id']);
 
             // get list of enabled users
-            $formSourceData['user_choices'] = $this->em->getRepository('DevlabsSportifyBundle:User')
+            $formSourceData['user_choices'] = $this->em->getRepository(User::class)
                 ->getAllEnabled();
         }
 

--- a/src/Devlabs/SportifyBundle/Services/ScoreUpdater.php
+++ b/src/Devlabs/SportifyBundle/Services/ScoreUpdater.php
@@ -5,6 +5,12 @@ namespace Devlabs\SportifyBundle\Services;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Doctrine\ORM\EntityManager;
+use Devlabs\SportifyBundle\Entity\Match;
+use Devlabs\SportifyBundle\Entity\Prediction;
+use Devlabs\SportifyBundle\Entity\PredictionChampion;
+use Devlabs\SportifyBundle\Entity\Score;
+use Devlabs\SportifyBundle\Entity\Tournament;
+use Devlabs\SportifyBundle\Entity\User;
 
 /**
  * Class ScoreUpdater
@@ -60,7 +66,7 @@ class ScoreUpdater
     {
         // get tournament
         $tournament = $this->em
-            ->getRepository('DevlabsSportifyBundle:Tournament')
+            ->getRepository(Tournament::class)
             ->findOneById($tournament_id);
 
         $tournamentsModified = array();
@@ -79,7 +85,7 @@ class ScoreUpdater
     {
         // get all tournaments
         $tournamentsAll = $this->em
-            ->getRepository('DevlabsSportifyBundle:Tournament')
+            ->getRepository(Tournament::class)
             ->findAll();
 
         foreach ($tournamentsAll as $tournament) {
@@ -87,7 +93,7 @@ class ScoreUpdater
             if ($tournament->getChampionTeamId() == null) continue;
 
             $championPredictions = $this->em
-                ->getRepository('DevlabsSportifyBundle:PredictionChampion')
+                ->getRepository(PredictionChampion::class)
                 ->getNotScoredByTournament($tournament);
 
             foreach ($championPredictions as $champPrediction) {
@@ -110,7 +116,7 @@ class ScoreUpdater
                  */
                 if ($predictionPoints > 0) {
                     $userScore = $this->em
-                        ->getRepository('DevlabsSportifyBundle:Score')
+                        ->getRepository(Score::class)
                         ->findOneBy(array(
                             'userId' => $champPrediction->getUserId(),
                             'tournamentId' => $champPrediction->getTournamentId(),
@@ -142,11 +148,11 @@ class ScoreUpdater
          * Get a list of the finished matches
          * for which there are NOT SCORED predictions
          */
-        $matches = $this->em->getRepository('DevlabsSportifyBundle:Match')
+        $matches = $this->em->getRepository(Match::class)
             ->getFinishedNotScored();
 
         // get list of enabled users
-        $users = $this->em->getRepository('DevlabsSportifyBundle:User')
+        $users = $this->em->getRepository(User::class)
             ->getAllEnabled();
 
         // iterate for each user
@@ -154,7 +160,7 @@ class ScoreUpdater
             /**
              * Get the list of scores (tournament + points) for the user
              */
-            $scores = $this->em->getRepository('DevlabsSportifyBundle:Score')
+            $scores = $this->em->getRepository(Score::class)
                 ->getByUser($user);
 
             /**
@@ -162,7 +168,7 @@ class ScoreUpdater
              * for matches with final score set
              */
             $predictions = $this->em
-                ->getRepository('DevlabsSportifyBundle:Prediction')
+                ->getRepository(Prediction::class)
                 ->getFinishedNotScored($user);
 
             // iterate on all of the user's predictions
@@ -196,7 +202,7 @@ class ScoreUpdater
                     $tournamentsModified[] = $tournament;
 
                     $tournamentScores = $this->em
-                        ->getRepository('DevlabsSportifyBundle:Score')
+                        ->getRepository(Score::class)
                         ->getByTournamentOrderByPosNew($tournament);
 
                     // keep all users' previous points
@@ -234,11 +240,11 @@ class ScoreUpdater
     private function calculatePredictionPercentage(&$tournamentsModified)
     {
         foreach ($tournamentsModified as $tournament) {
-            $scores = $this->em->getRepository('DevlabsSportifyBundle:Score')
+            $scores = $this->em->getRepository(Score::class)
                 ->getByTournamentOrderByPoints($tournament);
 
             $matchesFinished = $this->em
-                ->getRepository('DevlabsSportifyBundle:Match')
+                ->getRepository(Match::class)
                 ->getFinishedByTournament($tournament);
 
             $matchCount = count($matchesFinished);
@@ -246,7 +252,7 @@ class ScoreUpdater
             foreach ($scores as &$score) {
                 $user = $score->getUserId();
                 $predictionsExact = $this->em
-                    ->getRepository('DevlabsSportifyBundle:Prediction')
+                    ->getRepository(Prediction::class)
                     ->getExactPredictionsByUserAndTournament($user, $tournament);
 
                 $predictionCount = count($predictionsExact);
@@ -271,7 +277,7 @@ class ScoreUpdater
     private function calculateUserPositions(&$tournamentsModified)
     {
         foreach ($tournamentsModified as $tournament) {
-            $scores = $this->em->getRepository('DevlabsSportifyBundle:Score')
+            $scores = $this->em->getRepository(Score::class)
                 ->getByTournamentOrderByPoints($tournament);
 
             $position = 0;

--- a/src/Devlabs/SportifyBundle/Services/TwigHelper.php
+++ b/src/Devlabs/SportifyBundle/Services/TwigHelper.php
@@ -5,6 +5,7 @@ namespace Devlabs\SportifyBundle\Services;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Doctrine\ORM\EntityManager;
+use Devlabs\SportifyBundle\Entity\Score;
 use Devlabs\SportifyBundle\Entity\User;
 
 /**
@@ -31,7 +32,7 @@ class TwigHelper
     public function setUserScores(User $user)
     {
         // get scores standings for user
-        $userScores = $this->em->getRepository('DevlabsSportifyBundle:Score')
+        $userScores = $this->em->getRepository(Score::class)
             ->getByUser($user);
 
         // set user scores as Twig global var

--- a/tests/Functional/RegistrationLoginTest.php
+++ b/tests/Functional/RegistrationLoginTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Functional;
 
+use Devlabs\SportifyBundle\Entity\User;
 use Doctrine\ORM\Tools\SchemaTool;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
@@ -30,7 +31,7 @@ class RegistrationLoginTest extends WebTestCase
         $client->followRedirect();
         $this->assertTrue($client->getResponse()->isSuccessful());
 
-        $user = $em->getRepository('DevlabsSportifyBundle:User')->findOneBy(array('email' => $email));
+        $user = $em->getRepository(User::class)->findOneBy(array('email' => $email));
         $this->assertNotNull($user);
         $this->assertTrue($user->isEnabled());
         $this->assertNull($user->getConfirmationToken());

--- a/tests/Integration/PredictionWorkflowTest.php
+++ b/tests/Integration/PredictionWorkflowTest.php
@@ -4,7 +4,11 @@ namespace Tests\Integration;
 
 require_once __DIR__.'/DatabaseTestCase.php';
 
+use Devlabs\SportifyBundle\Entity\Match;
 use Devlabs\SportifyBundle\Entity\Prediction;
+use Devlabs\SportifyBundle\Entity\Score;
+use Devlabs\SportifyBundle\Entity\Tournament;
+use Devlabs\SportifyBundle\Entity\User;
 
 class PredictionWorkflowTest extends DatabaseTestCase
 {
@@ -27,7 +31,7 @@ class PredictionWorkflowTest extends DatabaseTestCase
         $this->createPrediction($exactUser, $finishedMatch, 2, 1);
         $this->createPrediction($outcomeUser, $finishedMatch, 1, 0);
 
-        $predictionRepository = $this->em->getRepository('DevlabsSportifyBundle:Prediction');
+        $predictionRepository = $this->em->getRepository(Prediction::class);
         $notScored = $predictionRepository->getFinishedNotScored($exactUser);
         $this->assertArrayHasKey($finishedMatch->getId(), $notScored);
 
@@ -36,11 +40,11 @@ class PredictionWorkflowTest extends DatabaseTestCase
 
         $this->em->clear();
 
-        $finishedMatch = $this->em->getRepository('DevlabsSportifyBundle:Match')->find($finishedMatch->getId());
-        $upcomingMatch = $this->em->getRepository('DevlabsSportifyBundle:Match')->find($upcomingMatch->getId());
-        $exactUser = $this->em->getRepository('DevlabsSportifyBundle:User')->find($exactUser->getId());
-        $outcomeUser = $this->em->getRepository('DevlabsSportifyBundle:User')->find($outcomeUser->getId());
-        $tournament = $this->em->getRepository('DevlabsSportifyBundle:Tournament')->find($tournament->getId());
+        $finishedMatch = $this->em->getRepository(Match::class)->find($finishedMatch->getId());
+        $upcomingMatch = $this->em->getRepository(Match::class)->find($upcomingMatch->getId());
+        $exactUser = $this->em->getRepository(User::class)->find($exactUser->getId());
+        $outcomeUser = $this->em->getRepository(User::class)->find($outcomeUser->getId());
+        $tournament = $this->em->getRepository(Tournament::class)->find($tournament->getId());
 
         $exactPrediction = $predictionRepository->getOneByUserAndMatch($exactUser, $finishedMatch);
         $outcomePrediction = $predictionRepository->getOneByUserAndMatch($outcomeUser, $finishedMatch);
@@ -52,7 +56,7 @@ class PredictionWorkflowTest extends DatabaseTestCase
         $this->assertSame(2, $exactPrediction->getResultHomeGoals());
         $this->assertSame(1, $exactPrediction->getResultAwayGoals());
 
-        $scoreRepository = $this->em->getRepository('DevlabsSportifyBundle:Score');
+        $scoreRepository = $this->em->getRepository(Score::class);
         $exactScore = $scoreRepository->getByUserAndTournament($exactUser, $tournament);
         $outcomeScore = $scoreRepository->getByUserAndTournament($outcomeUser, $tournament);
 

--- a/tests/Integration/RepositoryAndHelperTest.php
+++ b/tests/Integration/RepositoryAndHelperTest.php
@@ -4,7 +4,14 @@ namespace Tests\Integration;
 
 require_once __DIR__.'/DatabaseTestCase.php';
 
+use Devlabs\SportifyBundle\Entity\ApiMapping;
+use Devlabs\SportifyBundle\Entity\Match;
 use Devlabs\SportifyBundle\Entity\Prediction;
+use Devlabs\SportifyBundle\Entity\PredictionChampion;
+use Devlabs\SportifyBundle\Entity\Score;
+use Devlabs\SportifyBundle\Entity\Team;
+use Devlabs\SportifyBundle\Entity\Tournament;
+use Devlabs\SportifyBundle\Entity\User;
 use Symfony\Component\HttpFoundation\Request;
 
 class RepositoryAndHelperTest extends DatabaseTestCase
@@ -30,15 +37,15 @@ class RepositoryAndHelperTest extends DatabaseTestCase
         $tournamentsHelper->joinTournament($alice, $league);
         self::$kernel->getContainer()->get('app.score_updater')->updateUserPositionsForTournament($cup->getId());
 
-        $tournamentRepository = $this->em->getRepository('DevlabsSportifyBundle:Tournament');
+        $tournamentRepository = $this->em->getRepository(Tournament::class);
         $this->assertSame($cup->getId(), $tournamentRepository->getFirst()->getId());
         $this->assertSame(array($cup->getId(), $league->getId()), $this->ids($tournamentRepository->getJoined($alice)));
 
-        $teamRepository = $this->em->getRepository('DevlabsSportifyBundle:Team');
+        $teamRepository = $this->em->getRepository(Team::class);
         $this->assertSame($cupTeam->getId(), $teamRepository->getFirstByTournament($cup)->getId());
         $this->assertSame(array($cupTeam->getId()), $this->ids($teamRepository->getAllByTournament($cup)));
 
-        $scoreRepository = $this->em->getRepository('DevlabsSportifyBundle:Score');
+        $scoreRepository = $this->em->getRepository(Score::class);
         $aliceCupScore = $scoreRepository->getByUserAndTournament($alice, $cup);
         $bobCupScore = $scoreRepository->getByUserAndTournament($bob, $cup);
         $aliceCupScore->setPoints(3);
@@ -51,7 +58,7 @@ class RepositoryAndHelperTest extends DatabaseTestCase
         $this->assertSame($aliceCupScore->getId(), $scoreRepository->getAllHashed()[$cup->getId()][$alice->getId()]->getId());
         $this->assertSame(array($bobCupScore->getId(), $aliceCupScore->getId()), $this->ids($scoreRepository->getByTournamentOrderByPoints($cup)));
 
-        $userRepository = $this->em->getRepository('DevlabsSportifyBundle:User');
+        $userRepository = $this->em->getRepository(User::class);
         $this->assertSame(array($alice->getId(), $bob->getId()), $this->ids($userRepository->getAllEnabled()));
 
         $urlParams = array(
@@ -105,9 +112,9 @@ class RepositoryAndHelperTest extends DatabaseTestCase
         $this->createPrediction($user, $finishedScored, 0, 0, 1, Prediction::POINTS_EXACT);
         $this->createPrediction($otherUser, $upcomingUnpredicted, 0, 0);
 
-        $matchRepository = $this->em->getRepository('DevlabsSportifyBundle:Match');
-        $predictionRepository = $this->em->getRepository('DevlabsSportifyBundle:Prediction');
-        $userRepository = $this->em->getRepository('DevlabsSportifyBundle:User');
+        $matchRepository = $this->em->getRepository(Match::class);
+        $predictionRepository = $this->em->getRepository(Prediction::class);
+        $userRepository = $this->em->getRepository(User::class);
 
         $this->assertSame(array($upcomingPredicted->getId()), array_keys($predictionRepository->getNotScored($user, 'all', '2020-01-01', '2020-01-31')));
         $this->assertSame(array($finishedScored->getId()), array_keys($predictionRepository->getAlreadyScored($user, 'all', '2020-01-01', '2020-01-31')));
@@ -159,13 +166,13 @@ class RepositoryAndHelperTest extends DatabaseTestCase
 
         $this->em->clear();
 
-        $tournament = $this->em->getRepository('DevlabsSportifyBundle:Tournament')->find($tournament->getId());
-        $rightUser = $this->em->getRepository('DevlabsSportifyBundle:User')->find($rightUser->getId());
-        $wrongUser = $this->em->getRepository('DevlabsSportifyBundle:User')->find($wrongUser->getId());
-        $rightPrediction = $this->em->getRepository('DevlabsSportifyBundle:PredictionChampion')->find($rightPrediction->getId());
-        $wrongPrediction = $this->em->getRepository('DevlabsSportifyBundle:PredictionChampion')->find($wrongPrediction->getId());
+        $tournament = $this->em->getRepository(Tournament::class)->find($tournament->getId());
+        $rightUser = $this->em->getRepository(User::class)->find($rightUser->getId());
+        $wrongUser = $this->em->getRepository(User::class)->find($wrongUser->getId());
+        $rightPrediction = $this->em->getRepository(PredictionChampion::class)->find($rightPrediction->getId());
+        $wrongPrediction = $this->em->getRepository(PredictionChampion::class)->find($wrongPrediction->getId());
 
-        $predictionChampionRepository = $this->em->getRepository('DevlabsSportifyBundle:PredictionChampion');
+        $predictionChampionRepository = $this->em->getRepository(PredictionChampion::class);
         $this->assertSame($rightPrediction->getId(), $predictionChampionRepository->getByUserAndTournament($rightUser, $tournament)->getId());
         $this->assertSame(array(), $predictionChampionRepository->getNotScoredByTournament($tournament));
         $this->assertSame(5, $rightPrediction->getPoints());
@@ -173,7 +180,7 @@ class RepositoryAndHelperTest extends DatabaseTestCase
         $this->assertTrue((bool) $rightPrediction->getScoreAdded());
         $this->assertTrue((bool) $wrongPrediction->getScoreAdded());
 
-        $scoreRepository = $this->em->getRepository('DevlabsSportifyBundle:Score');
+        $scoreRepository = $this->em->getRepository(Score::class);
         $this->assertSame(5, $scoreRepository->getByUserAndTournament($rightUser, $tournament)->getPoints());
         $this->assertSame(0, $scoreRepository->getByUserAndTournament($wrongUser, $tournament)->getPoints());
     }
@@ -182,7 +189,7 @@ class RepositoryAndHelperTest extends DatabaseTestCase
     {
         $tournament = $this->createTournament('Mapped Cup');
         $mapping = $this->createApiMapping($tournament, 'Tournament', 'football-data', 987);
-        $repository = $this->em->getRepository('DevlabsSportifyBundle:ApiMapping');
+        $repository = $this->em->getRepository(ApiMapping::class);
 
         $this->assertSame($mapping->getId(), $repository->getByEntityTypeAndApiObjectId('Tournament', 'football-data', 987)->getId());
         $this->assertSame($mapping->getId(), $repository->getByEntityAndApiProvider($tournament, 'Tournament', 'football-data')->getId());

--- a/tests/Integration/UserCreationTest.php
+++ b/tests/Integration/UserCreationTest.php
@@ -4,6 +4,8 @@ namespace Tests\Integration;
 
 require_once __DIR__.'/DatabaseTestCase.php';
 
+use Devlabs\SportifyBundle\Entity\User;
+
 class UserCreationTest extends DatabaseTestCase
 {
     public function testCreateUserPersistsAllRequiredFields()
@@ -11,7 +13,7 @@ class UserCreationTest extends DatabaseTestCase
         $user = $this->createUser('alice_test');
 
         $this->em->clear();
-        $fetched = $this->em->getRepository('DevlabsSportifyBundle:User')->find($user->getId());
+        $fetched = $this->em->getRepository(User::class)->find($user->getId());
 
         $this->assertNotNull($fetched);
         $this->assertSame('alice_test', $fetched->getUsername());
@@ -26,7 +28,7 @@ class UserCreationTest extends DatabaseTestCase
         $user = $this->createUser('bob_disabled', false);
 
         $this->em->clear();
-        $fetched = $this->em->getRepository('DevlabsSportifyBundle:User')->find($user->getId());
+        $fetched = $this->em->getRepository(User::class)->find($user->getId());
 
         $this->assertNotNull($fetched);
         $this->assertFalse($fetched->isEnabled());
@@ -37,7 +39,7 @@ class UserCreationTest extends DatabaseTestCase
         $enabled = $this->createUser('enabled_user');
         $disabled = $this->createUser('disabled_user', false);
 
-        $allEnabled = $this->em->getRepository('DevlabsSportifyBundle:User')->getAllEnabled();
+        $allEnabled = $this->em->getRepository(User::class)->getAllEnabled();
         $enabledIds = array_map(function ($u) { return $u->getId(); }, $allEnabled);
 
         $this->assertContains($enabled->getId(), $enabledIds);


### PR DESCRIPTION
Migrate every `DevlabsSportifyBundle:Entity` string in app code to the fully qualified class name via `::class` so the codebase no longer relies on short bundle aliases that Doctrine Persistence 3 will drop.