### PR TITLE
Replace Swiftmailer with Symfony Mailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ After doing any changes on **app/config/parameters.yml** run `php bin/console ca
 
 ### Changing advanced app settings (app/config/parameters.yml):
  
-`mailer_dsn` - SMTP settings for registration confirmation and password reset emails. Put the SMTP username and password before the host: `smtp://USERNAME:PASSWORD@SMTP_HOST:PORT`. Example: `smtp://user%40example.com:app-password@smtp.example.com:587`. URL-encode special characters, e.g. `@` becomes `%40`.
+`mailer_dsn` - SMTP settings for registration confirmation and password reset emails. Put the SMTP username and password before the host: `smtp://USERNAME:PASSWORD@SMTP_HOST:PORT`. Example for username `user@example.com` and password `app-password`: `smtp://user%40example.com:app-password@smtp.example.com:587`. Only encode special characters inside `USERNAME`/`PASSWORD`; the `@` before `SMTP_HOST` separates credentials from the host, so keep it as `@`.
 
 `mailer_sender_address` - the email address used as the `From` address.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ After doing any changes on **app/config/parameters.yml** run `php bin/console ca
 
 ### Changing advanced app settings (app/config/parameters.yml):
  
-`mailer_host`, `mailer_port`, `mailer_user`, `mailer_password` - SMTP settings in order to have sending of registration confirmation and password reset emails enabled.
+`mailer_dsn` - SMTP settings for registration confirmation and password reset emails. Put the SMTP username and password before the host: `smtp://USERNAME:PASSWORD@SMTP_HOST:PORT`. Example: `smtp://user%40example.com:app-password@smtp.example.com:587`. URL-encode special characters, e.g. `@` becomes `%40`.
+
+`mailer_sender_address` - the email address used as the `From` address.
 
 Best practice is to use a transactional mail service, like Mailgun, Amazon SES, etc. We recommend Mailgun as registering an account takes a few minutes and the free tier should be enough. Another option is to use [Gmail SMTP settings](https://www.digitalocean.com/community/tutorials/how-to-use-google-s-smtp-server).  
 

--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,7 @@
 - GitHub Actions CI workflow is in place and green on main.
 - Symfony deprecation notices have been reduced to the remaining vendor-level batch.
 - `symfony/monolog-bundle` has been upgraded to 3.6, removing it from the Symfony 4.4 blocker list.
-- `symfony/swiftmailer-bundle` has been upgraded to 3.3 and Swiftmailer to 6.3, removing it from the Symfony 4.4 blocker list while keeping full Mailer replacement deferred.
+- Swiftmailer and `symfony/swiftmailer-bundle` have been replaced with Symfony Mailer for registration and password reset email delivery.
 - `jms/serializer-bundle` has been upgraded to 3.10 and `willdurand/hateoas-bundle` to 2.6, removing them from the Symfony 5.4 blocker list and removing the old `doctrine/common ~2` constraint from Hateoas.
 - `symfony/phpunit-bridge` has been upgraded to 5.4, with `SYMFONY_PHPUNIT_VERSION=7.5` pinned for the legacy PHPUnit test suite.
 - Composer package constraints have been reviewed for the current Symfony 4.4/PHP 7.4 baseline; unused `sensio/generator-bundle` was removed and `doctrine/doctrine-cache-bundle` is no longer a direct dependency.
@@ -26,8 +26,8 @@
 - The leftover `Team` unique-entity validation annotation has been moved to YAML.
 - The app bootstrap no longer manually registers Doctrine's annotation autoloader.
 - `doctrine/annotations` is no longer a direct dependency; it remains installed transitively through Doctrine ORM, JMS serializer, and Hateoas.
-- Current email usage is registration/password reset through Swiftmailer; full Mailer replacement is still deferred.
-- Current abandoned packages in `composer.lock`: `doctrine/annotations`, `doctrine/cache`, `swiftmailer/swiftmailer`, and `symfony/swiftmailer-bundle`.
+- Current email usage is registration/password reset through Symfony Mailer.
+- Current abandoned packages in `composer.lock`: `doctrine/annotations` and `doctrine/cache`.
 - FOSUserBundle has been removed; login, logout, registration, and password reset now use Symfony Security with the app `User` entity/provider/checker.
 - FOSOAuthServerBundle has been removed; password-grant token issuance and API access-token authentication now use small app-owned services/controllers against the existing OAuth tables.
 - FOSRestBundle and NelmioApiDocBundle have been removed; API routes are explicit YAML routes and API JSON responses are serialized directly with JMS Serializer.
@@ -58,9 +58,7 @@ Keep each milestone as a PR and verify from a clean Docker state before moving o
 
 1. Symfony 5.4 blocker-removal PR(s), grouped by subsystem rather than tiny package changes:
    - Keep Doctrine annotation removal grouped by ORM mapping work; ORM mappings still rely on annotations.
-   - Defer Swiftmailer replacement until the app can install `symfony/mailer`, unless it becomes a hard Symfony 5.4 blocker.
 2. Post-5.4 modernization PR(s):
-   - Replace Swiftmailer with Symfony Mailer.
    - Re-check abandoned packages and `composer why-not` output.
    - Add any missing tests discovered during the 5.4 upgrade.
 3. Continue one LTS at a time:

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -12,7 +12,6 @@ class AppKernel extends Kernel
             new Symfony\Bundle\SecurityBundle\SecurityBundle(),
             new Symfony\Bundle\TwigBundle\TwigBundle(),
             new Symfony\Bundle\MonologBundle\MonologBundle(),
-            new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Devlabs\SportifyBundle\DevlabsSportifyBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -25,6 +25,8 @@ framework:
     form:            ~
     csrf_protection: ~
     validation:      ~
+    mailer:
+        dsn: "%mailer_dsn%"
 #    serializer:
 #        enabled: true
 #        enable_annotations: true
@@ -66,15 +68,6 @@ doctrine:
         auto_generate_proxy_classes: "%kernel.debug%"
         naming_strategy: doctrine.orm.naming_strategy.underscore
         auto_mapping: true
-
-# Swiftmailer Configuration
-swiftmailer:
-    transport: "%mailer_transport%"
-    host:      "%mailer_host%"
-    port:      "%mailer_port%"
-    username:  "%mailer_user%"
-    password:  "%mailer_password%"
-    spool:     { type: memory }
 
 jms_serializer:
     metadata:

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -30,8 +30,5 @@ monolog:
         #    type:   chromephp
         #    level:  info
 
-#swiftmailer:
-#    delivery_address: me@example.com
-
 parameters:
     app.registration_confirmation_enabled: false

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -7,13 +7,12 @@ framework:
         storage_id: session.storage.mock_file
     profiler:
         collect: false
+    mailer:
+        dsn: 'null://null'
 
 web_profiler:
     toolbar: false
     intercept_redirects: false
-
-swiftmailer:
-    disable_delivery: true
 
 services:
     test.doctrine.orm.entity_manager:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -8,6 +8,10 @@ parameters:
     database_password: ~
 
     # mail
+    # Put SMTP username/password in the DSN before the host:
+    # smtp://USERNAME:PASSWORD@SMTP_HOST:PORT
+    # Example: smtp://user%40example.com:app-password@smtp.example.com:587
+    # URL-encode special characters, e.g. @ becomes %40.
     mailer_dsn:        smtp://127.0.0.1:587
     mailer_sender_address: change-me@example.com
 

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -10,8 +10,10 @@ parameters:
     # mail
     # Put SMTP username/password in the DSN before the host:
     # smtp://USERNAME:PASSWORD@SMTP_HOST:PORT
-    # Example: smtp://user%40example.com:app-password@smtp.example.com:587
-    # URL-encode special characters, e.g. @ becomes %40.
+    # Example for username "user@example.com" and password "app-password":
+    # smtp://user%40example.com:app-password@smtp.example.com:587
+    # Only encode special characters inside USERNAME/PASSWORD.
+    # The @ before SMTP_HOST separates credentials from host, so keep it as @.
     mailer_dsn:        smtp://127.0.0.1:587
     mailer_sender_address: change-me@example.com
 

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -8,11 +8,7 @@ parameters:
     database_password: ~
 
     # mail
-    mailer_transport:  smtp
-    mailer_host:       127.0.0.1
-    mailer_port:       587
-    mailer_user:       ~
-    mailer_password:   ~
+    mailer_dsn:        smtp://127.0.0.1:587
     mailer_sender_address: change-me@example.com
 
     # secret used for generating security-related tokens

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "symfony/symfony": "5.4.*",
         "doctrine/orm": "^2.11",
         "doctrine/doctrine-bundle": "^2.7",
-        "symfony/swiftmailer-bundle": "^3.5",
         "symfony/monolog-bundle": "^3.0",
         "symfony/polyfill-apcu": "^1.0",
         "incenteev/composer-parameter-handler": "^2.0",
@@ -32,7 +31,8 @@
         "doctrine/dbal": "^2.13",
         "doctrine/persistence": "^2.2",
         "symfony/contracts": "^2.1",
-        "symfony/doctrine-messenger": "^5.4"
+        "symfony/doctrine-messenger": "^5.4",
+        "egulias/email-validator": "^3.2"
     },
     "scripts": {
         "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "27b3f69dbe2f4768d1b7375272cb1110",
+    "content-hash": "65eb94ce7fdb3901ddc987884b4a0c8b",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -2598,82 +2598,6 @@
             "time": "2019-03-08T08:55:37+00:00"
         },
         {
-            "name": "swiftmailer/swiftmailer",
-            "version": "v6.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "8a5d5072dca8f48460fce2f4131fcc495eec654c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/8a5d5072dca8f48460fce2f4131fcc495eec654c",
-                "reference": "8a5d5072dca8f48460fce2f4131fcc495eec654c",
-                "shasum": ""
-            },
-            "require": {
-                "egulias/email-validator": "^2.0|^3.1",
-                "php": ">=7.0.0",
-                "symfony/polyfill-iconv": "^1.0",
-                "symfony/polyfill-intl-idn": "^1.10",
-                "symfony/polyfill-mbstring": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^1.0",
-                "symfony/phpunit-bridge": "^4.4|^5.4"
-            },
-            "suggest": {
-                "ext-intl": "Needed to support internationalized email addresses"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "6.2-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "lib/swift_required.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Chris Corbyn"
-                },
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                }
-            ],
-            "description": "Swiftmailer, free feature-rich PHP mailer",
-            "homepage": "https://swiftmailer.symfony.com",
-            "keywords": [
-                "email",
-                "mail",
-                "mailer"
-            ],
-            "support": {
-                "issues": "https://github.com/swiftmailer/swiftmailer/issues",
-                "source": "https://github.com/swiftmailer/swiftmailer/tree/v6.3.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/swiftmailer/swiftmailer",
-                    "type": "tidelift"
-                }
-            ],
-            "abandoned": "symfony/mailer",
-            "time": "2021-10-18T15:26:12+00:00"
-        },
-        {
             "name": "symfony/contracts",
             "version": "v2.5.5",
             "source": {
@@ -3068,90 +2992,6 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-04-10T16:19:22+00:00"
-        },
-        {
-            "name": "symfony/polyfill-iconv",
-            "version": "v1.37.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-iconv.git",
-                "reference": "2c5729fd241b4b22f6e4b436bc3354a4f262df57"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-iconv/zipball/2c5729fd241b4b22f6e4b436bc3354a4f262df57",
-                "reference": "2c5729fd241b4b22f6e4b436bc3354a4f262df57",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "provide": {
-                "ext-iconv": "*"
-            },
-            "suggest": {
-                "ext-iconv": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Iconv\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for the Iconv extension",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "iconv",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-iconv/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -3991,87 +3831,6 @@
                 }
             ],
             "time": "2026-04-10T16:19:22+00:00"
-        },
-        {
-            "name": "symfony/swiftmailer-bundle",
-            "version": "v3.5.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/swiftmailer-bundle.git",
-                "reference": "9daab339f226ac958192bf89836cb3378cc0e652"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/swiftmailer-bundle/zipball/9daab339f226ac958192bf89836cb3378cc0e652",
-                "reference": "9daab339f226ac958192bf89836cb3378cc0e652",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1",
-                "swiftmailer/swiftmailer": "^6.1.3",
-                "symfony/config": "^4.4|^5.0",
-                "symfony/dependency-injection": "^4.4|^5.0",
-                "symfony/http-kernel": "^4.4|^5.0"
-            },
-            "conflict": {
-                "twig/twig": "<1.41|>=2.0,<2.10"
-            },
-            "require-dev": {
-                "symfony/console": "^4.4|^5.0",
-                "symfony/framework-bundle": "^4.4|^5.0",
-                "symfony/phpunit-bridge": "^4.4|^5.0",
-                "symfony/yaml": "^4.4|^5.0"
-            },
-            "type": "symfony-bundle",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.5-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Bundle\\SwiftmailerBundle\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony SwiftmailerBundle",
-            "homepage": "http://symfony.com",
-            "support": {
-                "issues": "https://github.com/symfony/swiftmailer-bundle/issues",
-                "source": "https://github.com/symfony/swiftmailer-bundle/tree/v3.5.4"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "abandoned": "symfony/mailer",
-            "time": "2022-02-06T08:03:40+00:00"
         },
         {
             "name": "symfony/symfony",

--- a/docker/symfony/parameters.yml
+++ b/docker/symfony/parameters.yml
@@ -5,11 +5,7 @@ parameters:
     database_user: sportify
     database_password: sportify
 
-    mailer_transport: smtp
-    mailer_host: 127.0.0.1
-    mailer_port: 587
-    mailer_user: ~
-    mailer_password: ~
+    mailer_dsn: smtp://127.0.0.1:587
     mailer_sender_address: change-me@example.com
 
     secret: DockerOnlyDevelopmentSecret

--- a/src/Devlabs/SportifyBundle/Controller/RegistrationController.php
+++ b/src/Devlabs/SportifyBundle/Controller/RegistrationController.php
@@ -8,6 +8,7 @@ use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Mime\Email;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -108,12 +109,12 @@ class RegistrationController extends AbstractController
         $context = array('user' => $user, 'confirmationUrl' => $confirmationUrl);
         $twigTemplate = $this->get('twig')->load($template);
 
-        $message = (new \Swift_Message())
-            ->setSubject(trim($twigTemplate->renderBlock('subject', $context)))
-            ->setFrom($this->getParameter('mailer_sender_address'))
-            ->setTo($user->getEmail())
-            ->setBody($twigTemplate->renderBlock('body_text', $context), 'text/plain')
-            ->addPart($twigTemplate->renderBlock('body_html', $context), 'text/html')
+        $message = (new Email())
+            ->subject(trim($twigTemplate->renderBlock('subject', $context)))
+            ->from($this->getParameter('mailer_sender_address'))
+            ->to($user->getEmail())
+            ->text($twigTemplate->renderBlock('body_text', $context))
+            ->html($twigTemplate->renderBlock('body_html', $context))
         ;
 
         $this->get('mailer')->send($message);

--- a/src/Devlabs/SportifyBundle/Controller/ResettingController.php
+++ b/src/Devlabs/SportifyBundle/Controller/ResettingController.php
@@ -7,6 +7,7 @@ use Devlabs\SportifyBundle\Form\ResettingFormType;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Mime\Email;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class ResettingController extends AbstractController
@@ -96,12 +97,12 @@ class ResettingController extends AbstractController
         $context = array('user' => $user, 'confirmationUrl' => $confirmationUrl);
         $template = $this->get('twig')->load('templates/emails/password_resetting.email.twig');
 
-        $message = (new \Swift_Message())
-            ->setSubject(trim($template->renderBlock('subject', $context)))
-            ->setFrom($this->getParameter('mailer_sender_address'))
-            ->setTo($user->getEmail())
-            ->setBody($template->renderBlock('body_text', $context), 'text/plain')
-            ->addPart($template->renderBlock('body_html', $context), 'text/html')
+        $message = (new Email())
+            ->subject(trim($template->renderBlock('subject', $context)))
+            ->from($this->getParameter('mailer_sender_address'))
+            ->to($user->getEmail())
+            ->text($template->renderBlock('body_text', $context))
+            ->html($template->renderBlock('body_html', $context))
         ;
 
         $this->get('mailer')->send($message);


### PR DESCRIPTION
Replaces Swiftmailer usage/config with Symfony Mailer for registration and password reset emails.