### PR TITLE
Remove doctrine annotations dependency

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -17,7 +17,7 @@
 - `jms/serializer-bundle` has been upgraded to 5.5, `jms/serializer` to 3.32, and `willdurand/hateoas-bundle` to 2.6, removing the old `doctrine/common ~2` constraint from Hateoas.
 - `symfony/phpunit-bridge` has been upgraded to 7.4, with PHPUnit 9.6 pinned for the legacy test suite.
 - Composer package constraints have been reviewed for the current Symfony 7.4/PHP 8.2 baseline; unused `sensio/generator-bundle` was removed and `doctrine/doctrine-cache-bundle` is no longer a direct dependency.
-- Remaining abandoned packages are tied to legacy dependencies and should be handled as separate migrations.
+- No abandoned Composer packages are currently known in `composer.lock`.
 - `doctrine/doctrine-bundle` has been upgraded to 2.18, Doctrine ORM to 3.6, Doctrine DBAL to 3.10, Doctrine Persistence to 3.4, Doctrine Event Manager to 2.1, and `doctrine/doctrine-cache-bundle`/`doctrine/cache`/`doctrine/reflection` have been removed.
 - Short `DevlabsSportifyBundle:Entity` aliases in app code have been replaced with FQCN/`::class`, and remaining short aliases live only in vendor bridges.
 - SensioFrameworkExtraBundle has been removed; former admin-only security annotations are explicit controller checks.
@@ -25,18 +25,17 @@
 - App validation constraints have been moved from annotations to YAML, and Symfony validator annotation loading is disabled.
 - The leftover `Team` unique-entity validation annotation has been moved to YAML.
 - The app bootstrap no longer manually registers Doctrine's annotation autoloader.
-- `doctrine/annotations` is no longer a direct dependency; it remains installed transitively through DoctrineBundle and Hateoas.
+- `doctrine/annotations` has been removed.
 - Current email usage is registration/password reset through Symfony Mailer.
 - Doctrine ORM mappings have been moved from annotations to XML files in `app/config/doctrine`.
-- Current abandoned packages in `composer.lock`: `doctrine/annotations`, which remains through Hateoas/legacy Doctrine compatibility constraints.
+- Current abandoned packages in `composer.lock`: none known.
 - FOSUserBundle has been removed; login, logout, registration, and password reset now use Symfony Security with the app `User` entity/provider/checker.
 - FOSOAuthServerBundle has been removed; password-grant token issuance and API access-token authentication now use small app-owned services/controllers against the existing OAuth tables.
 - FOSRestBundle and NelmioApiDocBundle have been removed; API routes are explicit YAML routes and API JSON responses are serialized directly with JMS Serializer.
 - The unsupported `symfony/symfony` meta-package has been replaced with explicit Symfony component packages pinned to 7.4.*.
 - `phpunit.xml.dist` has been migrated to the PHPUnit 9.6 schema.
 - Symfony 7.4 is installed and locked; re-check deprecation output before the next backend milestone.
-- Remaining abandoned packages in `composer.lock`: `doctrine/annotations`.
-- Backend work should now focus on post-7.4 stabilization and remaining legacy dependency cleanup.
+- Backend work should now focus on infrastructure runtime upgrades.
 
 ## Next steps
 
@@ -64,7 +63,7 @@ Keep each milestone as a PR and verify from a clean Docker state before moving o
    - Re-check abandoned packages and deprecation output after each blocker-removal step.
    - Add any missing tests discovered during the Symfony 7.4 upgrade.
 2. Legacy dependency cleanup:
-   - Remove `doctrine/annotations` by upgrading/replacing the remaining dependency chain that keeps it installed.
+   - Done: `doctrine/annotations` has been removed by upgrading the remaining Hateoas dependency chain.
 3. Infrastructure runtime upgrades:
    - Upgrade Docker PHP from 8.2 to 8.5 in a focused PR after Symfony 7.4 stabilization.
    - Upgrade Docker MySQL from 5.7 to 8 in a separate focused PR after the PHP 8.5 runtime is stable.

--- a/TODO.md
+++ b/TODO.md
@@ -59,16 +59,11 @@ Use bigger PRs, but keep them coherent:
 
 Keep each milestone as a PR and verify from a clean Docker state before moving on.
 
-1. Symfony 7.4 stabilization PR(s):
-   - Re-check abandoned packages and deprecation output after each blocker-removal step.
-   - Add any missing tests discovered during the Symfony 7.4 upgrade.
-2. Legacy dependency cleanup:
-   - Done: `doctrine/annotations` has been removed by upgrading the remaining Hateoas dependency chain.
-3. Infrastructure runtime upgrades:
+1. Infrastructure runtime upgrades:
    - Upgrade Docker PHP from 8.2 to 8.5 in a focused PR after Symfony 7.4 stabilization.
    - Upgrade Docker MySQL from 5.7 to 8 in a separate focused PR after the PHP 8.5 runtime is stable.
    - For MySQL 8, explicitly check schema compatibility, reserved words, SQL modes, charset/collation behavior, and Doctrine schema validation output.
-4. Defer structural modernization until a framework step requires it:
+2. Defer structural modernization until a framework step requires it:
    - Do not migrate the directory layout or frontend toolchain opportunistically.
    - Prefer compatibility shims and focused route/config changes over broad rewrites unless a milestone explicitly calls for a replacement.
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "guzzlehttp/guzzle": "~6.0",
         "intervention/image": "^2.3",
         "jms/serializer-bundle": "^5.5",
-        "willdurand/hateoas-bundle": "^2.4",
+        "willdurand/hateoas-bundle": "^3.0",
         "doctrine/dbal": "^3.6",
         "doctrine/persistence": "^3.1",
         "symfony/contracts": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,85 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2f0b9a623f2350c21106f3b001785f28",
+    "content-hash": "28d2481c722061cb421258d9adc45714",
     "packages": [
-        {
-            "name": "doctrine/annotations",
-            "version": "2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/annotations.git",
-                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/901c2ee5d26eb64ff43c47976e114bf00843acf7",
-                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/lexer": "^2 || ^3",
-                "ext-tokenizer": "*",
-                "php": "^7.2 || ^8.0",
-                "psr/cache": "^1 || ^2 || ^3"
-            },
-            "require-dev": {
-                "doctrine/cache": "^2.0",
-                "doctrine/coding-standard": "^10",
-                "phpstan/phpstan": "^1.10.28",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "symfony/cache": "^5.4 || ^6.4 || ^7",
-                "vimeo/psalm": "^4.30 || ^5.14"
-            },
-            "suggest": {
-                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "Docblock Annotations Parser",
-            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
-            "keywords": [
-                "annotations",
-                "docblock",
-                "parser"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/2.0.2"
-            },
-            "abandoned": true,
-            "time": "2024-09-05T10:17:24+00:00"
-        },
         {
             "name": "doctrine/collections",
             "version": "2.6.0",
@@ -7548,35 +7471,35 @@
         },
         {
             "name": "willdurand/hateoas",
-            "version": "3.11.0",
+            "version": "3.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/willdurand/Hateoas.git",
-                "reference": "73fcb546b22df5d8e3483ba9a48820f499009acd"
+                "reference": "d7ce7ec7759da610905e909cf7554b07903ed250"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/willdurand/Hateoas/zipball/73fcb546b22df5d8e3483ba9a48820f499009acd",
-                "reference": "73fcb546b22df5d8e3483ba9a48820f499009acd",
+                "url": "https://api.github.com/repos/willdurand/Hateoas/zipball/d7ce7ec7759da610905e909cf7554b07903ed250",
+                "reference": "d7ce7ec7759da610905e909cf7554b07903ed250",
                 "shasum": ""
             },
             "require": {
-                "doctrine/annotations": "^1.13.2 || ^2.0",
                 "jms/metadata": "^2.0",
                 "jms/serializer": "^3.18.2",
-                "php": "^7.2 | ^8.0",
-                "symfony/expression-language": "~3.0 || ~4.0 || ~5.0 || ~6.0 || ~7.0"
+                "php": "^8.1",
+                "symfony/expression-language": "^5.4 || ^6.4 || ^7.3 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^12.0",
+                "doctrine/annotations": "^1.13.2 || ^2.0",
+                "doctrine/coding-standard": "^13.0.1",
                 "doctrine/persistence": "^1.3.4 | ^2.0 | ^3.0",
-                "pagerfanta/core": "^2.4 || ^3.0",
+                "pagerfanta/core": "^2.4 || ^3.0 || ^4.0",
                 "phpdocumentor/type-resolver": "^1.5.1",
                 "phpspec/prophecy": "^1.16",
                 "phpspec/prophecy-phpunit": "^2.0.1",
-                "phpunit/phpunit": "^7 | ^9.5.10",
-                "symfony/routing": "~3.0 || ~4.0 || ~5.0 || ~6.0 || ~7.0",
-                "symfony/yaml": "~3.0 || ~4.0 || ~5.0 || ~6.0 || ~7.0",
+                "phpunit/phpunit": "^10.5.38",
+                "symfony/routing": "^5.4 || ^6.4 || ^7.3 || ^8.0",
+                "symfony/yaml": "^5.4 || ^6.4 || ^7.3 || ^8.0",
                 "twig/twig": "^1.43 || ^2.13 || ^3.0"
             },
             "suggest": {
@@ -7616,39 +7539,40 @@
             "description": "A PHP library to support implementing representations for HATEOAS REST web services",
             "support": {
                 "issues": "https://github.com/willdurand/Hateoas/issues",
-                "source": "https://github.com/willdurand/Hateoas/tree/3.11.0"
+                "source": "https://github.com/willdurand/Hateoas/tree/3.14.0"
             },
-            "time": "2024-10-15T19:28:23+00:00"
+            "time": "2026-01-10T10:10:03+00:00"
         },
         {
             "name": "willdurand/hateoas-bundle",
-            "version": "2.6.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/willdurand/BazingaHateoasBundle.git",
-                "reference": "ccbdde8356ef02cbc72ac7ec40c7f1db3382b4ef"
+                "reference": "1ae8ff2388853fb9b35c8de5a1bbdb7f5554dfb8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/willdurand/BazingaHateoasBundle/zipball/ccbdde8356ef02cbc72ac7ec40c7f1db3382b4ef",
-                "reference": "ccbdde8356ef02cbc72ac7ec40c7f1db3382b4ef",
+                "url": "https://api.github.com/repos/willdurand/BazingaHateoasBundle/zipball/1ae8ff2388853fb9b35c8de5a1bbdb7f5554dfb8",
+                "reference": "1ae8ff2388853fb9b35c8de5a1bbdb7f5554dfb8",
                 "shasum": ""
             },
             "require": {
-                "jms/serializer-bundle": "^3.1 || ^4.2 || ^5.0",
-                "php": "^7.2 || ^8.0",
-                "symfony/expression-language": "~3.0 || ~4.0 || ~5.0 || ~6.0 || ~7.0",
-                "symfony/framework-bundle": "~3.0 || ~4.0 || ~5.0 || ~6.0 || ~7.0",
-                "willdurand/hateoas": "^3.5"
+                "jms/serializer-bundle": "^3.10 || ^4.2 || ^5.4",
+                "php": "^8.1",
+                "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0 || ~8.0",
+                "symfony/expression-language": "~5.0 || ~6.0 || ~7.0 || ~8.0",
+                "symfony/framework-bundle": "~5.0 || ~6.0 || ~7.0 || ~8.0",
+                "willdurand/hateoas": "^3.12@beta"
             },
             "conflict": {
                 "jms/serializer": "<3.18"
             },
             "require-dev": {
                 "doctrine/annotations": "^1.13.2 || ^2.0",
-                "doctrine/coding-standard": "^8.0",
-                "phpunit/phpunit": "^8.5.32 || ^9.5.10",
-                "symfony/stopwatch": "~3.0 || ~4.0 || ~5.0 || ~6.0 || ~7.0",
+                "doctrine/coding-standard": "^13.0.1",
+                "phpunit/phpunit": "^10.5.38",
+                "symfony/stopwatch": "~5.0 || ~6.0 || ~7.0 || ~8.0",
                 "twig/twig": "~1.12|~2.0|~3.0"
             },
             "type": "symfony-bundle",
@@ -7679,9 +7603,9 @@
             ],
             "support": {
                 "issues": "https://github.com/willdurand/BazingaHateoasBundle/issues",
-                "source": "https://github.com/willdurand/BazingaHateoasBundle/tree/2.6.0"
+                "source": "https://github.com/willdurand/BazingaHateoasBundle/tree/3.0.0"
             },
-            "time": "2023-12-13T11:29:05+00:00"
+            "time": "2025-12-21T12:15:53+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Devlabs/SportifyBundle/DependencyInjection/Compiler/RemoveJmsAnnotationDriverPass.php
+++ b/src/Devlabs/SportifyBundle/DependencyInjection/Compiler/RemoveJmsAnnotationDriverPass.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Devlabs\SportifyBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+class RemoveJmsAnnotationDriverPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('jms_serializer.metadata_driver')) {
+            return;
+        }
+
+        $definition = $container->getDefinition('jms_serializer.metadata_driver');
+        $drivers = array_filter(
+            $definition->getArgument(0),
+            static function ($driver) {
+                return !$driver instanceof Reference || 'jms_serializer.metadata.annotation_or_attribute_driver' !== (string) $driver;
+            }
+        );
+
+        $definition->replaceArgument(0, array_values($drivers));
+    }
+}

--- a/src/Devlabs/SportifyBundle/DevlabsSportifyBundle.php
+++ b/src/Devlabs/SportifyBundle/DevlabsSportifyBundle.php
@@ -3,6 +3,7 @@
 namespace Devlabs\SportifyBundle;
 
 use Devlabs\SportifyBundle\DependencyInjection\Compiler\PublicServicesPass;
+use Devlabs\SportifyBundle\DependencyInjection\Compiler\RemoveJmsAnnotationDriverPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -13,5 +14,6 @@ class DevlabsSportifyBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new PublicServicesPass());
+        $container->addCompilerPass(new RemoveJmsAnnotationDriverPass());
     }
 }


### PR DESCRIPTION
Upgrade Hateoas dependencies to remove doctrine/annotations and keep JMS Serializer on YAML metadata.