### PR TITLE
Clear remaining Symfony 7.4 app-level deprecations

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -34,7 +34,7 @@
 - FOSRestBundle and NelmioApiDocBundle have been removed; API routes are explicit YAML routes and API JSON responses are serialized directly with JMS Serializer.
 - The unsupported `symfony/symfony` meta-package has been replaced with explicit Symfony component packages pinned to 7.4.*.
 - `phpunit.xml.dist` has been migrated to the PHPUnit 9.6 schema.
-- Symfony 7.4 is installed and locked; re-check deprecation output before the next backend milestone.
+- Symfony 7.4 is installed and locked; deprecation re-check is clean for self and direct notices. The remaining 403 indirect notices are a single vendor deprecation (`Subscribing to onSchemaCreateTable events is deprecated`, doctrine/dbal) that needs a future DBAL major upgrade and is not actionable from app code.
 - Backend work should now focus on infrastructure runtime upgrades.
 
 ## Next steps

--- a/src/Devlabs/SportifyBundle/DevlabsSportifyBundle.php
+++ b/src/Devlabs/SportifyBundle/DevlabsSportifyBundle.php
@@ -9,7 +9,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class DevlabsSportifyBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/Devlabs/SportifyBundle/Entity/User.php
+++ b/src/Devlabs/SportifyBundle/Entity/User.php
@@ -75,6 +75,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
             && count($this->getRoles()) === count(array_intersect($this->getRoles(), $user->getRoles()));
     }
 
+    #[\Deprecated]
     public function eraseCredentials(): void
     {
         $this->plainPassword = null;

--- a/src/Devlabs/SportifyBundle/Form/ApiMappingType.php
+++ b/src/Devlabs/SportifyBundle/Form/ApiMappingType.php
@@ -16,7 +16,7 @@ class ApiMappingType extends AbstractType
     /**
      * @param OptionsResolver $resolver
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(array(
             'data_class' => 'Devlabs\SportifyBundle\Entity\ApiMapping',
@@ -28,7 +28,7 @@ class ApiMappingType extends AbstractType
      * @param FormBuilderInterface $builder
      * @param array $options
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $this->buttonAction = $options['button_action'];
 

--- a/src/Devlabs/SportifyBundle/Form/ChampionSelectType.php
+++ b/src/Devlabs/SportifyBundle/Form/ChampionSelectType.php
@@ -17,7 +17,7 @@ class ChampionSelectType extends AbstractType
     /**
      * @param OptionsResolver $resolver
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(array(
             'data_class' => null
@@ -28,7 +28,7 @@ class ChampionSelectType extends AbstractType
      * @param FormBuilderInterface $builder
      * @param array $options
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $this->data = $options['data'];
 

--- a/src/Devlabs/SportifyBundle/Form/ChangePasswordFormType.php
+++ b/src/Devlabs/SportifyBundle/Form/ChangePasswordFormType.php
@@ -10,7 +10,7 @@ use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
 
 class ChangePasswordFormType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('current_password', PasswordType::class, array(
@@ -28,7 +28,7 @@ class ChangePasswordFormType extends AbstractType
         ;
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'fos_user_change_password_form';
     }

--- a/src/Devlabs/SportifyBundle/Form/FilterType.php
+++ b/src/Devlabs/SportifyBundle/Form/FilterType.php
@@ -17,7 +17,7 @@ class FilterType extends AbstractType
     /**
      * @param OptionsResolver $resolver
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(array(
             'data_class' => null,
@@ -31,7 +31,7 @@ class FilterType extends AbstractType
      * @param FormBuilderInterface $builder
      * @param array $options
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $this->data = $options['data'];
         $this->fields = $options['fields'];

--- a/src/Devlabs/SportifyBundle/Form/MatchEntityType.php
+++ b/src/Devlabs/SportifyBundle/Form/MatchEntityType.php
@@ -29,7 +29,7 @@ class MatchEntityType extends AbstractType
     /**
      * @param OptionsResolver $resolver
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(array(
             'data_class' => 'Devlabs\SportifyBundle\Entity\MatchEntity',
@@ -42,7 +42,7 @@ class MatchEntityType extends AbstractType
      * @param FormBuilderInterface $builder
      * @param array $options
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $this->otherData = $options['other_data'];
         $this->buttonAction = $options['button_action'];

--- a/src/Devlabs/SportifyBundle/Form/PredictionType.php
+++ b/src/Devlabs/SportifyBundle/Form/PredictionType.php
@@ -27,7 +27,7 @@ class PredictionType extends AbstractType
     /**
      * @param OptionsResolver $resolver
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(array(
             'data_class' => 'Devlabs\SportifyBundle\Entity\Prediction',
@@ -39,7 +39,7 @@ class PredictionType extends AbstractType
      * @param FormBuilderInterface $builder
      * @param array $options
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $this->buttonAction = $options['button_action'];
 

--- a/src/Devlabs/SportifyBundle/Form/RegistrationFormType.php
+++ b/src/Devlabs/SportifyBundle/Form/RegistrationFormType.php
@@ -12,7 +12,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class RegistrationFormType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('email', EmailType::class, array(
@@ -37,14 +37,14 @@ class RegistrationFormType extends AbstractType
         ;
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(array(
             'data_class' => User::class,
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'fos_user_registration_form';
     }

--- a/src/Devlabs/SportifyBundle/Form/ResettingFormType.php
+++ b/src/Devlabs/SportifyBundle/Form/ResettingFormType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 class ResettingFormType extends AbstractType
 {
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder->add('plainPassword', RepeatedType::class, array(
             'type' => PasswordType::class,
@@ -20,7 +20,7 @@ class ResettingFormType extends AbstractType
         ));
     }
 
-    public function getBlockPrefix()
+    public function getBlockPrefix(): string
     {
         return 'fos_user_resetting_form';
     }

--- a/src/Devlabs/SportifyBundle/Form/TeamChoiceType.php
+++ b/src/Devlabs/SportifyBundle/Form/TeamChoiceType.php
@@ -16,7 +16,7 @@ class TeamChoiceType extends AbstractType
     /**
      * @param OptionsResolver $resolver
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(array(
             'data_class' => 'Devlabs\SportifyBundle\Entity\Team',
@@ -24,7 +24,7 @@ class TeamChoiceType extends AbstractType
         ));
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $this->data = $options['data'];
         $this->choices = $options['choices'];

--- a/src/Devlabs/SportifyBundle/Form/TeamEntityType.php
+++ b/src/Devlabs/SportifyBundle/Form/TeamEntityType.php
@@ -17,7 +17,7 @@ class TeamEntityType extends AbstractType
     /**
      * @param OptionsResolver $resolver
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(array(
             'data_class' => 'Devlabs\SportifyBundle\Entity\Team',
@@ -29,7 +29,7 @@ class TeamEntityType extends AbstractType
      * @param FormBuilderInterface $builder
      * @param array $options
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $this->buttonAction = $options['button_action'];
 

--- a/src/Devlabs/SportifyBundle/Form/TournamentChoiceType.php
+++ b/src/Devlabs/SportifyBundle/Form/TournamentChoiceType.php
@@ -16,7 +16,7 @@ class TournamentChoiceType extends AbstractType
     /**
      * @param OptionsResolver $resolver
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(array(
             'data_class' => 'Devlabs\SportifyBundle\Entity\Tournament',
@@ -24,7 +24,7 @@ class TournamentChoiceType extends AbstractType
         ));
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $this->data = $options['data'];
         $this->choices = $options['choices'];

--- a/src/Devlabs/SportifyBundle/Form/TournamentEntityType.php
+++ b/src/Devlabs/SportifyBundle/Form/TournamentEntityType.php
@@ -19,7 +19,7 @@ class TournamentEntityType extends AbstractType
     /**
      * @param OptionsResolver $resolver
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(array(
             'data_class' => 'Devlabs\SportifyBundle\Entity\Tournament',
@@ -32,7 +32,7 @@ class TournamentEntityType extends AbstractType
      * @param FormBuilderInterface $builder
      * @param array $options
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
 //        $this->otherData = $options['other_data'];
         $this->buttonAction = $options['button_action'];

--- a/src/Devlabs/SportifyBundle/Form/TournamentNullType.php
+++ b/src/Devlabs/SportifyBundle/Form/TournamentNullType.php
@@ -16,7 +16,7 @@ class TournamentNullType extends AbstractType
     /**
      * @param OptionsResolver $resolver
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(array(
             'data_class' => null
@@ -29,7 +29,7 @@ class TournamentNullType extends AbstractType
      * @param FormBuilderInterface $builder
      * @param array $options
      */
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $this->data = $options['data']['tournament_id'];
         $this->buttonAction = $options['data']['button_action'];

--- a/src/Devlabs/SportifyBundle/Form/UserChoiceType.php
+++ b/src/Devlabs/SportifyBundle/Form/UserChoiceType.php
@@ -16,7 +16,7 @@ class UserChoiceType extends AbstractType
     /**
      * @param OptionsResolver $resolver
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(array(
             'data_class' => 'Devlabs\SportifyBundle\Entity\User',
@@ -24,7 +24,7 @@ class UserChoiceType extends AbstractType
         ));
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $this->data = $options['data'];
         $this->choices = $options['choices'];

--- a/src/Devlabs/SportifyBundle/Form/UserType.php
+++ b/src/Devlabs/SportifyBundle/Form/UserType.php
@@ -16,14 +16,14 @@ class UserType extends AbstractType
     /**
      * @param OptionsResolver $resolver
      */
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults(array(
             'data_class' => 'Devlabs\SportifyBundle\Entity\User'
         ));
     }
 
-    public function buildForm(FormBuilderInterface $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('username')

--- a/src/Devlabs/SportifyBundle/Security/UserChecker.php
+++ b/src/Devlabs/SportifyBundle/Security/UserChecker.php
@@ -3,6 +3,7 @@
 namespace Devlabs\SportifyBundle\Security;
 
 use Devlabs\SportifyBundle\Entity\User;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AccountExpiredException;
 use Symfony\Component\Security\Core\Exception\CredentialsExpiredException;
 use Symfony\Component\Security\Core\Exception\DisabledException;
@@ -12,7 +13,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 class UserChecker implements UserCheckerInterface
 {
-    public function checkPreAuth(UserInterface $user): void
+    public function checkPreAuth(UserInterface $user, ?TokenInterface $token = null): void
     {
         if (!$user instanceof User) {
             return;
@@ -37,7 +38,7 @@ class UserChecker implements UserCheckerInterface
         }
     }
 
-    public function checkPostAuth(UserInterface $user): void
+    public function checkPostAuth(UserInterface $user, ?TokenInterface $token = null): void
     {
         if (!$user instanceof User) {
             return;

--- a/tests/Functional/FunctionalTestCase.php
+++ b/tests/Functional/FunctionalTestCase.php
@@ -34,7 +34,7 @@ abstract class FunctionalTestCase extends WebTestCase
     protected function resetDatabase()
     {
         $connection = $this->em->getConnection();
-        $schemaManager = $connection->getSchemaManager();
+        $schemaManager = $connection->createSchemaManager();
 
         $connection->executeQuery('SET FOREIGN_KEY_CHECKS=0');
         foreach ($schemaManager->listTableNames() as $tableName) {

--- a/tests/Functional/RegistrationLoginTest.php
+++ b/tests/Functional/RegistrationLoginTest.php
@@ -51,7 +51,7 @@ class RegistrationLoginTest extends WebTestCase
     private function resetDatabase($em)
     {
         $connection = $em->getConnection();
-        $schemaManager = $connection->getSchemaManager();
+        $schemaManager = $connection->createSchemaManager();
 
         $connection->executeQuery('SET FOREIGN_KEY_CHECKS=0');
         foreach ($schemaManager->listTableNames() as $tableName) {

--- a/tests/Integration/DatabaseTestCase.php
+++ b/tests/Integration/DatabaseTestCase.php
@@ -39,7 +39,7 @@ abstract class DatabaseTestCase extends KernelTestCase
     protected function resetDatabase()
     {
         $connection = $this->em->getConnection();
-        $schemaManager = $connection->getSchemaManager();
+        $schemaManager = $connection->createSchemaManager();
 
         $connection->executeQuery('SET FOREIGN_KEY_CHECKS=0');
         foreach ($schemaManager->listTableNames() as $tableName) {


### PR DESCRIPTION
Adds missing return types on bundle/form classes, the new `?TokenInterface` arg on `UserChecker`, `#[\Deprecated]` on `User::eraseCredentials()`, and switches test cases to `Connection::createSchemaManager()`. Self/direct deprecation notices are now zero; remaining indirect notices are a single vendor doctrine/dbal `onSchemaCreateTable` deprecation.