### PR TITLE
Upgrade Docker PHP to 8.5

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -62,7 +62,6 @@ Keep each milestone as a PR and verify from a clean Docker state before moving o
 1. Infrastructure runtime upgrades:
    - Upgrade Docker MySQL from 5.7 to 8 in a focused PR now that the PHP 8.5 runtime is stable.
    - For MySQL 8, explicitly check schema compatibility, reserved words, SQL modes, charset/collation behavior, and Doctrine schema validation output.
-   - After MySQL 8, plan a follow-up PR to address PHP 8.5 deprecation notices in app code (mostly implicit-nullable parameters on entity setters and test helpers). These are non-blocking under `SYMFONY_DEPRECATIONS_HELPER=weak`.
 2. Defer structural modernization until a framework step requires it:
    - Do not migrate the directory layout or frontend toolchain opportunistically.
    - Prefer compatibility shims and focused route/config changes over broad rewrites unless a milestone explicitly calls for a replacement.

--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@
 - Docker development setup exists and has been verified.
 - Docker httpd service serves `web/` static files and proxies dynamic requests to PHP.
 - Symfony has been upgraded to 7.4 LTS.
-- Docker PHP has been upgraded incrementally from 7.0 to 8.2.
+- Docker PHP has been upgraded incrementally from 7.0 to 8.5.
 - Composer dependencies have been updated to latest versions within existing constraints.
 - SensioDistributionBundle, its Composer script handlers, the generated requirements/config checker flow, and transitive sensiolabs/security-checker have been removed.
 - Basic integration workflow test exists for tournaments, users, predictions, scoring, standings, and helper/repository calls.
@@ -60,9 +60,9 @@ Use bigger PRs, but keep them coherent:
 Keep each milestone as a PR and verify from a clean Docker state before moving on.
 
 1. Infrastructure runtime upgrades:
-   - Upgrade Docker PHP from 8.2 to 8.5 in a focused PR after Symfony 7.4 stabilization.
-   - Upgrade Docker MySQL from 5.7 to 8 in a separate focused PR after the PHP 8.5 runtime is stable.
+   - Upgrade Docker MySQL from 5.7 to 8 in a focused PR now that the PHP 8.5 runtime is stable.
    - For MySQL 8, explicitly check schema compatibility, reserved words, SQL modes, charset/collation behavior, and Doctrine schema validation output.
+   - After MySQL 8, plan a follow-up PR to address PHP 8.5 deprecation notices in app code (mostly implicit-nullable parameters on entity setters and test helpers). These are non-blocking under `SYMFONY_DEPRECATIONS_HELPER=weak`.
 2. Defer structural modernization until a framework step requires it:
    - Do not migrate the directory layout or frontend toolchain opportunistically.
    - Prefer compatibility shims and focused route/config changes over broad rewrites unless a milestone explicitly calls for a replacement.

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
         }
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.5",
         "doctrine/orm": "^3",
         "doctrine/doctrine-bundle": "^2.18",
         "symfony/monolog-bundle": "^3.10",
         "symfony/polyfill-apcu": "^1.0",
-        "guzzlehttp/guzzle": "~6.0",
+        "guzzlehttp/guzzle": "^7.10",
         "intervention/image": "^2.3",
         "jms/serializer-bundle": "^5.5",
         "willdurand/hateoas-bundle": "^3.0",
@@ -77,7 +77,7 @@
     },
     "config": {
         "platform": {
-            "php": "8.2"
+            "php": "8.5"
         }
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "28d2481c722061cb421258d9adc45714",
+    "content-hash": "942b846de3259502f04ad9c1a35c187d",
     "packages": [
         {
             "name": "doctrine/collections",
@@ -1011,37 +1011,48 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.5.8",
+            "version": "7.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "a52f0440530b54fa079ce76e8c5d196a42cad981"
+                "reference": "47ba23c7a55247e2e1b7407aca90e9bbed0d9d86"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/a52f0440530b54fa079ce76e8c5d196a42cad981",
-                "reference": "a52f0440530b54fa079ce76e8c5d196a42cad981",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/47ba23c7a55247e2e1b7407aca90e9bbed0d9d86",
+                "reference": "47ba23c7a55247e2e1b7407aca90e9bbed0d9d86",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.9",
-                "php": ">=5.5",
-                "symfony/polyfill-intl-idn": "^1.17"
+                "guzzlehttp/promises": "^2.3",
+                "guzzlehttp/psr7": "^2.8",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
-                "psr/log": "^1.1"
+                "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.3.2",
+                "php-http/message-factory": "^1.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
                 "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-master": "6.5-dev"
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
                 }
             },
             "autoload": {
@@ -1094,19 +1105,20 @@
                 }
             ],
             "description": "Guzzle is a PHP HTTP client library",
-            "homepage": "http://guzzlephp.org/",
             "keywords": [
                 "client",
                 "curl",
                 "framework",
                 "http",
                 "http client",
+                "psr-18",
+                "psr-7",
                 "rest",
                 "web service"
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/6.5.8"
+                "source": "https://github.com/guzzle/guzzle/tree/7.10.3"
             },
             "funding": [
                 {
@@ -1122,33 +1134,37 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-06-20T22:16:07+00:00"
+            "time": "2026-05-20T22:59:19+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.5.3",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "67ab6e18aaa14d753cc148911d273f6e6cb6721e"
+                "reference": "09e8a212562fb1fb6a512c4156ed71525969d6c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/67ab6e18aaa14d753cc148911d273f6e6cb6721e",
-                "reference": "67ab6e18aaa14d753cc148911d273f6e6cb6721e",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/09e8a212562fb1fb6a512c4156ed71525969d6c2",
+                "reference": "09e8a212562fb1fb6a512c4156ed71525969d6c2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": "^7.2.5 || ^8.0"
             },
             "require-dev": {
-                "symfony/phpunit-bridge": "^4.4 || ^5.1"
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
             "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
                 "psr-4": {
                     "GuzzleHttp\\Promise\\": "src/"
                 }
@@ -1185,7 +1201,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/1.5.3"
+                "source": "https://github.com/guzzle/promises/tree/2.4.1"
             },
             "funding": [
                 {
@@ -1201,42 +1217,49 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-21T12:31:43+00:00"
+            "time": "2026-05-20T22:57:30+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.9.1",
+            "version": "2.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "e4490cabc77465aaee90b20cfc9a770f8c04be6b"
+                "reference": "73ab136360b5dfd858006eae9795e8fe43c80361"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/e4490cabc77465aaee90b20cfc9a770f8c04be6b",
-                "reference": "e4490cabc77465aaee90b20cfc9a770f8c04be6b",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/73ab136360b5dfd858006eae9795e8fe43c80361",
+                "reference": "73ab136360b5dfd858006eae9795e8fe43c80361",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0",
-                "psr/http-message": "~1.0",
-                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
+                "ralouphie/getallheaders": "^3.0"
             },
             "provide": {
+                "psr/http-factory-implementation": "1.0",
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "ext-zlib": "*",
-                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.10"
+                "bamarni/composer-bin-plugin": "^1.8.2",
+                "http-interop/http-factory-tests": "1.1.0",
+                "jshttp/mime-db": "1.54.0.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
             },
             "type": "library",
+            "extra": {
+                "bamarni-bin": {
+                    "bin-links": true,
+                    "forward-command": false
+                }
+            },
             "autoload": {
-                "files": [
-                    "src/functions_include.php"
-                ],
                 "psr-4": {
                     "GuzzleHttp\\Psr7\\": "src/"
                 }
@@ -1275,6 +1298,11 @@
                     "name": "Tobias Schultze",
                     "email": "webmaster@tubo-world.de",
                     "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
                 }
             ],
             "description": "PSR-7 message implementation that also provides common utility methods",
@@ -1290,7 +1318,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/1.9.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.10.1"
             },
             "funding": [
                 {
@@ -1306,7 +1334,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-17T16:00:37+00:00"
+            "time": "2026-05-20T09:27:36+00:00"
         },
         {
             "name": "intervention/image",
@@ -2064,26 +2092,79 @@
             "time": "2019-01-08T18:20:26+00:00"
         },
         {
-            "name": "psr/http-message",
-            "version": "1.1",
+            "name": "psr/http-client",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-fig/http-message.git",
-                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
-                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/bb5906edc1c324c9a05aa0873d40117941e5fa90",
+                "reference": "bb5906edc1c324c9a05aa0873d40117941e5fa90",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0"
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client"
+            },
+            "time": "2023-09-23T14:17:50+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
@@ -2098,7 +2179,61 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for HTTP messages",
@@ -2112,9 +2247,9 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/1.1"
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
             },
-            "time": "2023-04-04T09:50:52+00:00"
+            "time": "2023-04-04T09:54:51+00:00"
         },
         {
             "name": "psr/link",
@@ -9428,11 +9563,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.2"
+        "php": ">=8.5"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "8.2"
+        "php": "8.5"
     },
     "plugin-api-version": "2.2.0"
 }

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,6 +1,6 @@
 FROM composer:2.2.25 AS composer
 
-FROM php:8.2-cli-bookworm
+FROM php:8.5-cli-bookworm
 
 RUN set -eux; \
     apt-get update; \
@@ -19,7 +19,7 @@ RUN set -eux; \
         libonig-dev \
     ; \
     docker-php-ext-configure gd --with-freetype --with-jpeg; \
-    docker-php-ext-install -j"$(nproc)" curl gd intl mbstring opcache pdo_mysql zip; \
+    docker-php-ext-install -j"$(nproc)" curl gd intl mbstring pdo_mysql zip; \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=composer /usr/bin/composer /usr/local/bin/composer

--- a/src/Devlabs/SportifyBundle/Entity/MatchEntity.php
+++ b/src/Devlabs/SportifyBundle/Entity/MatchEntity.php
@@ -141,7 +141,7 @@ class MatchEntity
      *
      * @return Match
      */
-    public function setTournamentId(\Devlabs\SportifyBundle\Entity\Tournament $tournamentId = null)
+    public function setTournamentId(?\Devlabs\SportifyBundle\Entity\Tournament $tournamentId = null)
     {
         $this->tournamentId = $tournamentId;
 
@@ -247,7 +247,7 @@ class MatchEntity
      *
      * @return Match
      */
-    public function setHomeTeamId(\Devlabs\SportifyBundle\Entity\Team $homeTeamId = null)
+    public function setHomeTeamId(?\Devlabs\SportifyBundle\Entity\Team $homeTeamId = null)
     {
         $this->homeTeamId = $homeTeamId;
 
@@ -271,7 +271,7 @@ class MatchEntity
      *
      * @return Match
      */
-    public function setAwayTeamId(\Devlabs\SportifyBundle\Entity\Team $awayTeamId = null)
+    public function setAwayTeamId(?\Devlabs\SportifyBundle\Entity\Team $awayTeamId = null)
     {
         $this->awayTeamId = $awayTeamId;
 
@@ -309,7 +309,7 @@ class MatchEntity
      */
     public function getNotificationSent()
     {
-        return (boolean) $this->notificationSent;
+        return (bool) $this->notificationSent;
     }
 
     /**

--- a/src/Devlabs/SportifyBundle/Entity/Prediction.php
+++ b/src/Devlabs/SportifyBundle/Entity/Prediction.php
@@ -149,7 +149,7 @@ class Prediction
      *
      * @return Prediction
      */
-    public function setMatchId(\Devlabs\SportifyBundle\Entity\MatchEntity $matchId = null)
+    public function setMatchId(?\Devlabs\SportifyBundle\Entity\MatchEntity $matchId = null)
     {
         $this->matchId = $matchId;
 
@@ -173,7 +173,7 @@ class Prediction
      *
      * @return Prediction
      */
-    public function setUserId(\Devlabs\SportifyBundle\Entity\User $userId = null)
+    public function setUserId(?\Devlabs\SportifyBundle\Entity\User $userId = null)
     {
         $this->userId = $userId;
 

--- a/src/Devlabs/SportifyBundle/Entity/PredictionChampion.php
+++ b/src/Devlabs/SportifyBundle/Entity/PredictionChampion.php
@@ -84,7 +84,7 @@ class PredictionChampion
      *
      * @return PredictionWinner
      */
-    public function setUserId(\Devlabs\SportifyBundle\Entity\User $userId = null)
+    public function setUserId(?\Devlabs\SportifyBundle\Entity\User $userId = null)
     {
         $this->userId = $userId;
 
@@ -108,7 +108,7 @@ class PredictionChampion
      *
      * @return PredictionWinner
      */
-    public function setTournamentId(\Devlabs\SportifyBundle\Entity\Tournament $tournamentId = null)
+    public function setTournamentId(?\Devlabs\SportifyBundle\Entity\Tournament $tournamentId = null)
     {
         $this->tournamentId = $tournamentId;
 
@@ -132,7 +132,7 @@ class PredictionChampion
      *
      * @return PredictionWinner
      */
-    public function setTeamId(\Devlabs\SportifyBundle\Entity\Team $teamId = null)
+    public function setTeamId(?\Devlabs\SportifyBundle\Entity\Team $teamId = null)
     {
         $this->teamId = $teamId;
 

--- a/src/Devlabs/SportifyBundle/Entity/Score.php
+++ b/src/Devlabs/SportifyBundle/Entity/Score.php
@@ -62,7 +62,7 @@ class Score
      *
      * @return Score
      */
-    public function setUserId(\Devlabs\SportifyBundle\Entity\User $userId = null)
+    public function setUserId(?\Devlabs\SportifyBundle\Entity\User $userId = null)
     {
         $this->userId = $userId;
 
@@ -86,7 +86,7 @@ class Score
      *
      * @return Score
      */
-    public function setTournamentId(\Devlabs\SportifyBundle\Entity\Tournament $tournamentId = null)
+    public function setTournamentId(?\Devlabs\SportifyBundle\Entity\Tournament $tournamentId = null)
     {
         $this->tournamentId = $tournamentId;
 

--- a/src/Devlabs/SportifyBundle/Entity/Tournament.php
+++ b/src/Devlabs/SportifyBundle/Entity/Tournament.php
@@ -250,7 +250,7 @@ class Tournament
      *
      * @return Tournament
      */
-    public function setChampionTeamId(\Devlabs\SportifyBundle\Entity\Team $championTeamId = null)
+    public function setChampionTeamId(?\Devlabs\SportifyBundle\Entity\Team $championTeamId = null)
     {
         $this->championTeamId = $championTeamId;
 

--- a/src/Devlabs/SportifyBundle/Entity/User.php
+++ b/src/Devlabs/SportifyBundle/Entity/User.php
@@ -214,7 +214,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
         return $this->lastLogin;
     }
 
-    public function setLastLogin(\DateTime $lastLogin = null)
+    public function setLastLogin(?\DateTime $lastLogin = null)
     {
         $this->lastLogin = $lastLogin;
 
@@ -238,7 +238,7 @@ class User implements UserInterface, PasswordAuthenticatedUserInterface, Equatab
         return $this->passwordRequestedAt;
     }
 
-    public function setPasswordRequestedAt(\DateTime $passwordRequestedAt = null)
+    public function setPasswordRequestedAt(?\DateTime $passwordRequestedAt = null)
     {
         $this->passwordRequestedAt = $passwordRequestedAt;
 

--- a/tests/Integration/DatabaseTestCase.php
+++ b/tests/Integration/DatabaseTestCase.php
@@ -68,7 +68,7 @@ abstract class DatabaseTestCase extends KernelTestCase
         return $user;
     }
 
-    protected function createTournament($name, \DateTime $startDate = null, \DateTime $endDate = null)
+    protected function createTournament($name, ?\DateTime $startDate = null, ?\DateTime $endDate = null)
     {
         $tournament = new Tournament();
         $tournament->setName($name);
@@ -81,7 +81,7 @@ abstract class DatabaseTestCase extends KernelTestCase
         return $tournament;
     }
 
-    protected function createTeam($name, Tournament $tournament = null)
+    protected function createTeam($name, ?Tournament $tournament = null)
     {
         $team = new Team();
         $team->setName($name);


### PR DESCRIPTION
Bumps the Docker PHP image to 8.5-cli-bookworm, drops opcache from `docker-php-ext-install` since it's now built into the image, and upgrades Guzzle to 7.10 to clear the PHP 8.4+ implicit-nullable parameter deprecations that broke console output.