### PR TITLE
Plan frontend track ahead of MySQL upgrades; split verification by change type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,8 @@
 This is a legacy Symfony application being upgraded incrementally.
 
 Current baseline:
-- Symfony 6.4 LTS
-- PHP 8.2 in Docker
+- Symfony 7.4 LTS
+- PHP 8.5 in Docker
 - Apache httpd 2.4 in Docker serving `web/` and proxying dynamic requests to PHP
 - MySQL 5.7 in Docker
 - Composer 2.2.x in Docker
@@ -26,7 +26,6 @@ The project is intentionally old. Do not modernize broad areas unless the curren
 - Keep Docker as the source of truth for local verification.
 - Do not install host packages.
 - Do not commit secrets, API tokens, local `parameters.yml`, `vendor/`, `node_modules/`, `lib/`, generated assets, or cache/log files.
-- Commit and push changes yourself on non-`main` branches, then create a pull request.
 - Do not push on `main` unless explicitly asked.
 - Keep PR descriptions concise; do not add a detailed summary unless asked.
 - For user-facing web changes, verify the affected flow in a real local browser in addition to command-line smoke checks.
@@ -38,7 +37,6 @@ The project is intentionally old. Do not modernize broad areas unless the curren
 - For failing PHPUnit/Symfony runs, prefer extracting concise failure sections (for example, grep around `^[0-9]+)`), not full HTML error pages or full logs.
 - Keep searches targeted. Use narrower `rg` patterns, `--count`, or `head` before printing large match sets.
 - Prefer `git diff --stat` plus targeted diffs for risky files instead of printing broad diffs.
-- For doc-only changes, still commit and push on a non-`main` branch, but do not run local Docker verification or wait for CI unless explicitly asked.
 - Keep progress updates short and avoid repeating branch/verification details unless they changed or are needed for the final summary.
 
 ## Verification rule
@@ -80,11 +78,3 @@ curl -fsSI --max-time 10 http://localhost:8000/js/all-scripts.js
 Do not run the PHP test suite for frontend-only changes. Frontend modernization additionally requires browser-based verification by the agent: load the affected pages in a real browser and confirm the flow visibly works, not just that command-line smoke checks return 200.
 
 Leave Docker running after local verification so the user can test manually.
-
-## Upgrade strategy
-
-Preferred path:
-1. Keep Symfony 6.4 test suite passing.
-2. Resolve Symfony 6.4 deprecations and Symfony 7.4 blockers.
-3. Upgrade Docker PHP to the minimum supported version before Symfony 7.4.
-4. Keep frontend modernization separate from PHP/Symfony upgrades.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,30 +43,43 @@ The project is intentionally old. Do not modernize broad areas unless the curren
 
 ## Verification rule
 
-Before validating each upgrade step, reset Docker state:
-
-```sh
-docker compose down -v
-```
-
-Then verify from a clean setup as much as practical:
+Do not reset Docker state (`docker compose down -v`) before verification. If the stack is already up, reuse it. If it isn't, bring it up and make sure the database schema is in place before running checks:
 
 ```sh
 cp docker/symfony/parameters.yml app/config/parameters.yml
-docker compose build
+docker compose up --wait httpd
+docker compose run --rm php php bin/console doctrine:database:create --if-not-exists
+docker compose run --rm php php bin/console doctrine:schema:update --force
+```
+
+Then run only the suite that matches the type of change.
+
+### PHP / Symfony changes
+
+```sh
 docker compose run --rm php composer install --no-interaction --no-progress
+docker compose run --rm php php bin/console cache:clear --env=test
+docker compose run --rm php php bin/console doctrine:schema:validate
+docker compose run --rm php vendor/bin/simple-phpunit --testsuite 'Project Test Suite'
+curl -fsSI --max-time 10 http://localhost:8000/
+```
+
+Do not run the frontend asset pipeline for PHP-only changes.
+
+### Frontend changes
+
+```sh
 docker compose run --rm node npm install
 docker compose run --rm node bower install
 docker compose run --rm node gulp
-docker compose run --rm php php bin/console cache:clear --env=test
-docker compose run --rm php php bin/console doctrine:database:create --if-not-exists
-docker compose run --rm php php bin/console doctrine:schema:validate --skip-sync
-docker compose run --rm php php bin/console doctrine:schema:update --force
-docker compose run --rm php vendor/bin/simple-phpunit --testsuite 'Project Test Suite'
-docker compose up --wait httpd
-curl -I --max-time 10 http://localhost:8000/
-# Leave Docker running after local verification so the user can test manually.
+# docker compose run --rm node npm test   # once a frontend test suite exists — see TODO
+curl -fsSI --max-time 10 http://localhost:8000/css/style.css
+curl -fsSI --max-time 10 http://localhost:8000/js/all-scripts.js
 ```
+
+Do not run the PHP test suite for frontend-only changes. Frontend modernization additionally requires browser-based verification by the agent: load the affected pages in a real browser and confirm the flow visibly works, not just that command-line smoke checks return 200.
+
+Leave Docker running after local verification so the user can test manually.
 
 ## Upgrade strategy
 

--- a/TODO.md
+++ b/TODO.md
@@ -66,7 +66,6 @@ This is the active track. Keep each step as its own PR.
 2. Upgrade the Node/npm runtime in Docker in a focused PR.
 3. Replace Bower with an npm-based dependency flow in a focused PR.
 4. Replace Gulp 3 with a current build setup in a focused PR.
-5. Every frontend PR must include a browser-based check of the affected pages by the coding agent, not just command-line smoke checks.
 
 ## Deferred backend infrastructure path
 

--- a/TODO.md
+++ b/TODO.md
@@ -11,13 +11,11 @@
 - Basic integration workflow test exists for tournaments, users, predictions, scoring, standings, and helper/repository calls.
 - Functional auth coverage exists for login page CSRF, successful registration/login, failed login, logout, duplicate registration, registration validation, password reset, and profile password changes.
 - GitHub Actions CI workflow is in place and green on main.
-- Symfony deprecation notices have been reduced to the remaining vendor-level batch.
 - `symfony/monolog-bundle` has been upgraded to 3.10.
 - Swiftmailer and `symfony/swiftmailer-bundle` have been replaced with Symfony Mailer for registration and password reset email delivery.
 - `jms/serializer-bundle` has been upgraded to 5.5, `jms/serializer` to 3.32, and `willdurand/hateoas-bundle` to 2.6, removing the old `doctrine/common ~2` constraint from Hateoas.
 - `symfony/phpunit-bridge` has been upgraded to 7.4, with PHPUnit 9.6 pinned for the legacy test suite.
-- Composer package constraints have been reviewed for the current Symfony 7.4/PHP 8.2 baseline; unused `sensio/generator-bundle` was removed and `doctrine/doctrine-cache-bundle` is no longer a direct dependency.
-- No abandoned Composer packages are currently known in `composer.lock`.
+- Composer package constraints have been reviewed for the current Symfony 7.4/PHP 8.5 baseline; unused `sensio/generator-bundle` was removed and `doctrine/doctrine-cache-bundle` is no longer a direct dependency.
 - `doctrine/doctrine-bundle` has been upgraded to 2.18, Doctrine ORM to 3.6, Doctrine DBAL to 3.10, Doctrine Persistence to 3.4, Doctrine Event Manager to 2.1, and `doctrine/doctrine-cache-bundle`/`doctrine/cache`/`doctrine/reflection` have been removed.
 - Short `DevlabsSportifyBundle:Entity` aliases in app code have been replaced with FQCN/`::class`, and remaining short aliases live only in vendor bridges.
 - SensioFrameworkExtraBundle has been removed; former admin-only security annotations are explicit controller checks.
@@ -35,16 +33,10 @@
 - The unsupported `symfony/symfony` meta-package has been replaced with explicit Symfony component packages pinned to 7.4.*.
 - `phpunit.xml.dist` has been migrated to the PHPUnit 9.6 schema.
 - Symfony 7.4 is installed and locked; deprecation re-check is clean for self and direct notices. The remaining 403 indirect notices are a single vendor deprecation (`Subscribing to onSchemaCreateTable events is deprecated`, doctrine/dbal) that needs a future DBAL major upgrade and is not actionable from app code.
-- Backend work should now focus on infrastructure runtime upgrades.
 
 ## Next steps
 
-1. Stop splitting upgrade work into tiny deprecation-only PRs. Prefer larger, coherent milestone PRs that remove a full blocker or complete a framework step end-to-end.
-2. Add tests before each larger change so CI gives enough confidence to review and merge bigger PRs.
-3. Keep frontend modernization separate from backend/Symfony modernization unless a backend step explicitly requires a frontend change.
-4. Follow the post-Symfony 7.4 stabilization path and remove remaining legacy dependency blockers.
-5. Backend infrastructure (PHP runtime, Symfony, Doctrine) is good enough for now. Start the frontend modernization track next: Node 6 / Bower / Gulp 3 are far past EOL and are the most painful remaining baseline. This track needs the coding agent's browser skills: loading the affected pages locally and confirming the UI flows visibly work, not just that command-line smoke checks return 200.
-6. Defer the remaining backend infrastructure upgrades (MySQL 5.7 → 8 → 9) until after the frontend track is complete.
+Backend infrastructure (PHP runtime, Symfony, Doctrine) is good enough for now. The active track is frontend modernization (see "Frontend modernization path" below): Node 6 / Bower / Gulp 3 are far past EOL and are the most painful remaining baseline. Remaining backend infrastructure upgrades (MySQL 5.7 → 8 → 9) are deferred until the frontend track is complete.
 
 ## PR sizing strategy
 
@@ -80,42 +72,4 @@ Pick this back up only after the frontend modernization path is complete. Keep e
 
 ## Always verify each step
 
-Do not `docker compose down -v` before verifying. Reuse the running stack if it's already up; otherwise bring it up and create the schema:
-
-```sh
-cp docker/symfony/parameters.yml app/config/parameters.yml
-# CI also replaces football_api.token with the FOOTBALL_DATA_API_TOKEN secret before running.
-docker compose up --wait httpd
-docker compose run --rm php php bin/console doctrine:database:create --if-not-exists
-docker compose run --rm php php bin/console doctrine:schema:update --force
-```
-
-Then run only the suite that matches the type of change.
-
-### PHP / Symfony changes
-
-```sh
-docker compose run --rm php composer install --no-interaction --no-progress
-docker compose run --rm php php bin/console cache:clear --env=test
-docker compose run --rm php php bin/console cache:clear --env=dev
-docker compose run --rm php php bin/console doctrine:schema:validate
-docker compose run --rm php vendor/bin/simple-phpunit --testsuite 'Project Test Suite'
-curl -fsSI --max-time 10 http://localhost:8000/
-```
-
-Skip the Node/Bower/Gulp asset pipeline for PHP-only changes.
-
-### Frontend changes
-
-```sh
-docker compose run --rm node npm install
-docker compose run --rm node bower install
-docker compose run --rm node gulp
-# docker compose run --rm node npm test   # once a frontend test suite exists — see "Frontend modernization path"
-curl -fsSI --max-time 10 http://localhost:8000/css/style.css
-curl -fsSI --max-time 10 http://localhost:8000/js/all-scripts.js
-```
-
-Skip the PHP test suite for frontend-only changes. In addition to the smoke checks above, the coding agent must verify the affected pages in a real browser.
-
-Leave Docker running after local verification so the app can be tested manually.
+See the "Verification rule" section of `AGENTS.md`. Note: CI also replaces `football_api.token` with the `FOOTBALL_DATA_API_TOKEN` secret before running.

--- a/TODO.md
+++ b/TODO.md
@@ -43,7 +43,8 @@
 2. Add tests before each larger change so CI gives enough confidence to review and merge bigger PRs.
 3. Keep frontend modernization separate from backend/Symfony modernization unless a backend step explicitly requires a frontend change.
 4. Follow the post-Symfony 7.4 stabilization path and remove remaining legacy dependency blockers.
-5. Plan infrastructure upgrades as separate milestones: PHP 8.5 first, then MySQL 8.
+5. Plan infrastructure upgrades as separate milestones: PHP 8.5 first, then MySQL 8, then MySQL 9.
+6. After backend infrastructure is stable, start the frontend modernization track (Node 6 / Bower / Gulp 3 are far past EOL). This track needs the coding agent's browser skills: loading the affected pages locally and confirming the UI flows visibly work, not just that command-line smoke checks return 200.
 
 ## PR sizing strategy
 
@@ -62,33 +63,61 @@ Keep each milestone as a PR and verify from a clean Docker state before moving o
 1. Infrastructure runtime upgrades:
    - Upgrade Docker MySQL from 5.7 to 8 in a focused PR now that the PHP 8.5 runtime is stable.
    - For MySQL 8, explicitly check schema compatibility, reserved words, SQL modes, charset/collation behavior, and Doctrine schema validation output.
+   - Upgrade Docker MySQL from 8 to 9 in a separate focused PR after the MySQL 8 runtime is stable. Re-check schema compatibility, reserved words, SQL modes, charset/collation behavior, and Doctrine schema validation output against MySQL 9.
 2. Defer structural modernization until a framework step requires it:
    - Do not migrate the directory layout or frontend toolchain opportunistically.
    - Prefer compatibility shims and focused route/config changes over broad rewrites unless a milestone explicitly calls for a replacement.
 
+## Frontend modernization path
+
+Start this track only after the backend infrastructure path above is complete. Keep each step as its own PR.
+
+1. Add a frontend test suite before changing the frontend toolchain:
+   - The repo currently has no automated frontend tests. Pick a minimal runner that fits the existing Gulp/Bower setup (or the chosen replacement) and add smoke-level coverage for the assets the app actually ships (`web/css/style.css`, `web/js/all-scripts.js`, and the templates that load them).
+   - Until this exists, frontend changes can only be verified manually in a browser; CI cannot gate them.
+2. Upgrade the Node/npm runtime in Docker in a focused PR.
+3. Replace Bower with an npm-based dependency flow in a focused PR.
+4. Replace Gulp 3 with a current build setup in a focused PR.
+5. Every frontend PR must include a browser-based check of the affected pages by the coding agent, not just command-line smoke checks.
+
 ## Always verify each step
 
-Local verification should mirror `.github/workflows/ci.yml`, with an explicit clean reset before and after:
+Do not `docker compose down -v` before verifying. Reuse the running stack if it's already up; otherwise bring it up and create the schema:
 
 ```sh
-docker compose down -v
 cp docker/symfony/parameters.yml app/config/parameters.yml
 # CI also replaces football_api.token with the FOOTBALL_DATA_API_TOKEN secret before running.
-docker compose build
+docker compose up --wait httpd
+docker compose run --rm php php bin/console doctrine:database:create --if-not-exists
+docker compose run --rm php php bin/console doctrine:schema:update --force
+```
+
+Then run only the suite that matches the type of change.
+
+### PHP / Symfony changes
+
+```sh
 docker compose run --rm php composer install --no-interaction --no-progress
+docker compose run --rm php php bin/console cache:clear --env=test
+docker compose run --rm php php bin/console cache:clear --env=dev
+docker compose run --rm php php bin/console doctrine:schema:validate
+docker compose run --rm php vendor/bin/simple-phpunit --testsuite 'Project Test Suite'
+curl -fsSI --max-time 10 http://localhost:8000/
+```
+
+Skip the Node/Bower/Gulp asset pipeline for PHP-only changes.
+
+### Frontend changes
+
+```sh
 docker compose run --rm node npm install
 docker compose run --rm node bower install
 docker compose run --rm node gulp
-docker compose run --rm php php bin/console cache:clear --env=test
-docker compose run --rm php php bin/console cache:clear --env=dev
-docker compose run --rm php php bin/console doctrine:database:create --if-not-exists
-docker compose run --rm php php bin/console doctrine:schema:validate --skip-sync
-docker compose run --rm php php bin/console doctrine:schema:update --force
-docker compose run --rm php php bin/console doctrine:schema:validate
-docker compose run --rm php vendor/bin/simple-phpunit --testsuite 'Project Test Suite'
-docker compose up --wait httpd
-curl -fsSI --max-time 10 http://localhost:8000/
+# docker compose run --rm node npm test   # once a frontend test suite exists — see "Frontend modernization path"
 curl -fsSI --max-time 10 http://localhost:8000/css/style.css
 curl -fsSI --max-time 10 http://localhost:8000/js/all-scripts.js
-# Leave Docker running after local verification so the app can be tested manually.
 ```
+
+Skip the PHP test suite for frontend-only changes. In addition to the smoke checks above, the coding agent must verify the affected pages in a real browser.
+
+Leave Docker running after local verification so the app can be tested manually.

--- a/TODO.md
+++ b/TODO.md
@@ -43,8 +43,8 @@
 2. Add tests before each larger change so CI gives enough confidence to review and merge bigger PRs.
 3. Keep frontend modernization separate from backend/Symfony modernization unless a backend step explicitly requires a frontend change.
 4. Follow the post-Symfony 7.4 stabilization path and remove remaining legacy dependency blockers.
-5. Plan infrastructure upgrades as separate milestones: PHP 8.5 first, then MySQL 8, then MySQL 9.
-6. After backend infrastructure is stable, start the frontend modernization track (Node 6 / Bower / Gulp 3 are far past EOL). This track needs the coding agent's browser skills: loading the affected pages locally and confirming the UI flows visibly work, not just that command-line smoke checks return 200.
+5. Backend infrastructure (PHP runtime, Symfony, Doctrine) is good enough for now. Start the frontend modernization track next: Node 6 / Bower / Gulp 3 are far past EOL and are the most painful remaining baseline. This track needs the coding agent's browser skills: loading the affected pages locally and confirming the UI flows visibly work, not just that command-line smoke checks return 200.
+6. Defer the remaining backend infrastructure upgrades (MySQL 5.7 → 8 → 9) until after the frontend track is complete.
 
 ## PR sizing strategy
 
@@ -56,21 +56,9 @@ Use bigger PRs, but keep them coherent:
 - Prefer one PR per milestone below, not one PR per deprecation notice or one PR per small config line.
 - If a milestone uncovers unrelated work, note it in TODO instead of expanding scope indefinitely.
 
-## Backend stabilization path
-
-Keep each milestone as a PR and verify from a clean Docker state before moving on.
-
-1. Infrastructure runtime upgrades:
-   - Upgrade Docker MySQL from 5.7 to 8 in a focused PR now that the PHP 8.5 runtime is stable.
-   - For MySQL 8, explicitly check schema compatibility, reserved words, SQL modes, charset/collation behavior, and Doctrine schema validation output.
-   - Upgrade Docker MySQL from 8 to 9 in a separate focused PR after the MySQL 8 runtime is stable. Re-check schema compatibility, reserved words, SQL modes, charset/collation behavior, and Doctrine schema validation output against MySQL 9.
-2. Defer structural modernization until a framework step requires it:
-   - Do not migrate the directory layout or frontend toolchain opportunistically.
-   - Prefer compatibility shims and focused route/config changes over broad rewrites unless a milestone explicitly calls for a replacement.
-
 ## Frontend modernization path
 
-Start this track only after the backend infrastructure path above is complete. Keep each step as its own PR.
+This is the active track. Keep each step as its own PR.
 
 1. Add a frontend test suite before changing the frontend toolchain:
    - The repo currently has no automated frontend tests. Pick a minimal runner that fits the existing Gulp/Bower setup (or the chosen replacement) and add smoke-level coverage for the assets the app actually ships (`web/css/style.css`, `web/js/all-scripts.js`, and the templates that load them).
@@ -79,6 +67,17 @@ Start this track only after the backend infrastructure path above is complete. K
 3. Replace Bower with an npm-based dependency flow in a focused PR.
 4. Replace Gulp 3 with a current build setup in a focused PR.
 5. Every frontend PR must include a browser-based check of the affected pages by the coding agent, not just command-line smoke checks.
+
+## Deferred backend infrastructure path
+
+Pick this back up only after the frontend modernization path is complete. Keep each milestone as its own PR.
+
+1. Infrastructure runtime upgrades:
+   - Upgrade Docker MySQL from 5.7 to 8 in a focused PR.
+   - For MySQL 8, explicitly check schema compatibility, reserved words, SQL modes, charset/collation behavior, and Doctrine schema validation output.
+   - Upgrade Docker MySQL from 8 to 9 in a separate focused PR after the MySQL 8 runtime is stable. Re-check schema compatibility, reserved words, SQL modes, charset/collation behavior, and Doctrine schema validation output against MySQL 9.
+2. Defer structural modernization until a framework step requires it:
+   - Prefer compatibility shims and focused route/config changes over broad rewrites unless a milestone explicitly calls for a replacement.
 
 ## Always verify each step
 


### PR DESCRIPTION
Adds a MySQL 9 milestone after MySQL 8, adds a frontend modernization path (preceded by adding a frontend test suite) that requires browser-based verification, and rewrites the verification rule so it no longer wipes Docker state and runs only the suite matching the type of change.