### PR TITLE
Use npm for frontend dependencies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ The project is intentionally old. Do not modernize broad areas unless the curren
 - Do not push on `main` unless explicitly asked.
 - Keep PR descriptions concise; do not add a detailed summary unless asked.
 - For user-facing web changes, verify the affected flow in a real local browser in addition to command-line smoke checks.
+- If Chromium fails to start during browser verification, try launching it with `--no-sandbox`.
 - For changes limited to `AGENTS.md` and/or `TODO.md`, still commit and push on a non-`main` branch, but do not run local Docker verification or wait for CI unless explicitly asked.
 
 ## Output and token discipline

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a football (soccer :) match prediction game with a simple concept - you 
 * Symfony [system requirements](http://symfony.com/doc/current/reference/requirements.html)
 * [composer](https://getcomposer.org/)
 * [npm](https://docs.npmjs.com/getting-started/installing-node)
-* [bower](https://bower.io/) & [gulp](http://gulpjs.com/) installed globally 
+* [gulp](http://gulpjs.com/) installed globally 
 
 # Installation and Environment Setup
 The project can be run without issues on both *nix and Windows (Mac OS X, Ubuntu and Windows with LAMP tested :). Check [the A to Z wiki article](https://github.com/dev-labs-bg/sportify/wiki/Setting-up-the-project-on-DigitalOcean-droplet-from-A-to-Z) for a step by step guide on how to prepare a 5$ 512MB DigitalOcean Ubuntu LAMP 16.04 droplet for the task.
@@ -15,7 +15,6 @@ The major steps needed to set-up Symfony and all the tools (for both development
 
 `composer install` - *for a basic install you just need username and password for mysql, all are written to _app/config/parameters.yml_ check here for those the advanced parameters.*  
 `npm install` *(if running on a machine with 0.5/1GB RAM add swap)*  
-`bower install` *(you may need --allow-root as a parameter if running as sudo)*  
 `gulp`
 
 We suggest that you setup your web server to use `web/` as root directory.

--- a/TODO.md
+++ b/TODO.md
@@ -35,10 +35,11 @@
 - Symfony 7.4 is installed and locked; deprecation re-check is clean for self and direct notices. The remaining 403 indirect notices are a single vendor deprecation (`Subscribing to onSchemaCreateTable events is deprecated`, doctrine/dbal) that needs a future DBAL major upgrade and is not actionable from app code.
 - Minimal frontend smoke coverage exists through `npm test`.
 - Docker Node runtime has been upgraded from Node 6 / npm 3 to Node 7 / npm 4, the newest runtime the current `laravel-elixir`/`node-sass` stack supports without dependency changes.
+- Bower has been removed; frontend dependencies now install through npm.
 
 ## Next steps
 
-Backend infrastructure (PHP runtime, Symfony, Doctrine) is good enough for now. The active track is frontend modernization (see "Frontend modernization path" below): Node 6 / Bower / Gulp 3 are far past EOL and are the most painful remaining baseline. Remaining backend infrastructure upgrades (MySQL 5.7 → 8 → 9) are deferred until the frontend track is complete.
+Backend infrastructure (PHP runtime, Symfony, Doctrine) is good enough for now. The active track is frontend modernization (see "Frontend modernization path" below): Gulp 3 is the most painful remaining baseline. Remaining backend infrastructure upgrades (MySQL 5.7 → 8 → 9) are deferred until the frontend track is complete.
 
 ## PR sizing strategy
 
@@ -54,8 +55,7 @@ Use bigger PRs, but keep them coherent:
 
 This is the active track. Keep each step as its own PR.
 
-1. Replace Bower with an npm-based dependency flow in a focused PR.
-2. Replace Gulp 3 with a current build setup in a focused PR.
+1. Replace Gulp 3 with a current build setup in a focused PR.
 
 ## Deferred backend infrastructure path
 

--- a/bower.json
+++ b/bower.json
@@ -13,12 +13,5 @@
     "test",
     "tests"
   ],
-  "dependencies": {
-    "bootstrap-sass": "3.4.1",
-    "jquery": "#2.2.4",
-    "owl.carousel": "^2.1.5",
-    "chosen": "^1.5.1",
-    "bootstrap-datepicker": "^1.6.1",
-    "flag-icon-css": "^2.3.1"
-  }
+  "dependencies": {}
 }

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # Docker development baseline
 
-This setup is intentionally old: it is for reproducing the legacy PHP 7.0/Bower/Gulp stack while upgrading it incrementally.
+This setup is intentionally old: it is for reproducing the legacy PHP 7.0/Gulp stack while upgrading it incrementally.
 
 ## First run
 
@@ -10,7 +10,6 @@ cp docker/symfony/parameters.yml app/config/parameters.yml
 docker compose build
 docker compose run --rm php composer install --no-interaction --no-progress
 docker compose run --rm node npm install
-docker compose run --rm node bower install
 docker compose run --rm node gulp
 docker compose run --rm php vendor/bin/simple-phpunit --testsuite 'Project Test Suite'
 docker compose up php

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,19 +9,19 @@ elixir(function(mix) {
     .sass([
 
         'bootstrap.scss',
-        '../lib/owl.carousel/dist/assets/owl.carousel.min.css',
-        '../lib/bootstrap-datepicker/dist/css/bootstrap-datepicker.min.css',
-        '../lib/chosen/chosen.css',
+        '../node_modules/owl.carousel/dist/assets/owl.carousel.min.css',
+        '../node_modules/bootstrap-datepicker/dist/css/bootstrap-datepicker.min.css',
+        '../node_modules/chosen-js/chosen.css',
         'flag-icon.scss',
         'style.scss'
 
         ],'web/css/style.css')
     .scripts([
-        '../lib/jquery/dist/jquery.min.js',
-        '../lib/bootstrap-sass/assets/javascripts/bootstrap.min.js',
-        '../lib/owl.carousel/dist/owl.carousel.min.js',
-        '../lib/chosen/chosen.jquery.js',
-        '../lib/bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js',
+        '../node_modules/jquery/dist/jquery.min.js',
+        '../node_modules/bootstrap-sass/assets/javascripts/bootstrap.min.js',
+        '../node_modules/owl.carousel/dist/owl.carousel.min.js',
+        '../node_modules/chosen-js/chosen.jquery.js',
+        '../node_modules/bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js',
         '../web/js/script.js',
         ],'web/js/all-scripts.js');
 });

--- a/package.json
+++ b/package.json
@@ -8,8 +8,14 @@
     "gulp": "^3.9.1"
   },
   "dependencies": {
+    "bootstrap-datepicker": "^1.6.1",
+    "bootstrap-sass": "3.4.1",
+    "chosen-js": "^1.5.1",
+    "flag-icon-css": "^2.3.1",
+    "jquery": "2.2.4",
     "laravel-elixir": "^3.0.0",
     "material-datetime-picker": "^1.0.1",
+    "owl.carousel": "^2.1.5",
     "browser-sync": "2.26.7",
     "browser-sync-client": "2.26.6",
     "browser-sync-ui": "2.26.4"

--- a/sass/bootstrap.scss
+++ b/sass/bootstrap.scss
@@ -1,56 +1,56 @@
 /*!
  * Bootstrap v3.3.6 (http://getbootstrap.com)
  * Copyright 2011-2015 Twitter, Inc.
- * Licensed under MIT (https://github.com/twbs/../lib/bootstrap-sass/assets/stylesheets/bootstrap/blob/master/LICENSE)
+ * Licensed under MIT (https://github.com/twbs/../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/blob/master/LICENSE)
  */
 
 // Core variables and mixins
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/variables";
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/mixins";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/variables";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/mixins";
 
 // Reset and dependencies
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/normalize";
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/print";
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/glyphicons";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/normalize";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/print";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/glyphicons";
 
 // Core CSS
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/scaffolding";
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/type";
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/code";
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/grid";
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/tables";
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/forms";
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/buttons";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/scaffolding";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/type";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/code";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/grid";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/tables";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/forms";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/buttons";
 
 // Components
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/component-animations";
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/dropdowns";
-//@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/button-groups";
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/input-groups";
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/navs";
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/navbar";
-//@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/breadcrumbs";
-//@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/pagination";
-//@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/pager";
-//@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/labels";
-//@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/badges";
-//@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/jumbotron";
-//@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/thumbnails";
-//@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/alerts";
-//@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/progress-bars";
-//@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/media";
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/list-group";
-//@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/panels";
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/responsive-embed";
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/wells";
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/close";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/component-animations";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/dropdowns";
+//@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/button-groups";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/input-groups";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/navs";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/navbar";
+//@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/breadcrumbs";
+//@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/pagination";
+//@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/pager";
+//@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/labels";
+//@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/badges";
+//@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/jumbotron";
+//@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/thumbnails";
+//@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/alerts";
+//@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/progress-bars";
+//@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/media";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/list-group";
+//@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/panels";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/responsive-embed";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/wells";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/close";
 
 // Components w/ JavaScript
-//@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/modals";
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/tooltip";
-//@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/popovers";
-//@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/carousel";
+//@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/modals";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/tooltip";
+//@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/popovers";
+//@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/carousel";
 
 // Utility classes
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/utilities";
-@import "../lib/bootstrap-sass/assets/stylesheets/bootstrap/responsive-utilities";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/utilities";
+@import "../node_modules/bootstrap-sass/assets/stylesheets/bootstrap/responsive-utilities";

--- a/sass/flag-icon.scss
+++ b/sass/flag-icon.scss
@@ -1,4 +1,4 @@
-@import "../lib/flag-icon-css/sass/variables";
-@import "../lib/flag-icon-css/sass/flag-icon-base";
-@import "../lib/flag-icon-css/sass/flag-icon-list";
-@import "../lib/flag-icon-css/sass/flag-icon-more";
+@import "../node_modules/flag-icon-css/sass/variables";
+@import "../node_modules/flag-icon-css/sass/flag-icon-base";
+@import "../node_modules/flag-icon-css/sass/flag-icon-list";
+@import "../node_modules/flag-icon-css/sass/flag-icon-more";


### PR DESCRIPTION
Moves asset dependencies from Bower to npm while keeping the existing Gulp build.