### PR TITLE
Replace Laravel Elixir with Gulp 4 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
       - name: Build frontend assets
         run: |
           docker compose run --rm node npm install
-          docker compose run --rm node bower install
           docker compose run --rm node gulp
 
       - name: Run Symfony and Doctrine smoke checks

--- a/TODO.md
+++ b/TODO.md
@@ -36,10 +36,11 @@
 - Minimal frontend smoke coverage exists through `npm test`.
 - Docker Node runtime has been upgraded from Node 6 / npm 3 to Node 7 / npm 4, the newest runtime the current `laravel-elixir`/`node-sass` stack supports without dependency changes.
 - Bower has been removed; frontend dependencies now install through npm.
+- Gulp 3 and Laravel Elixir have been replaced with a plain Gulp 4 build.
 
 ## Next steps
 
-Backend infrastructure (PHP runtime, Symfony, Doctrine) is good enough for now. The active track is frontend modernization (see "Frontend modernization path" below): Gulp 3 is the most painful remaining baseline. Remaining backend infrastructure upgrades (MySQL 5.7 → 8 → 9) are deferred until the frontend track is complete.
+Backend infrastructure (PHP runtime, Symfony, Doctrine) is good enough for now. The active track is frontend modernization (see "Frontend modernization path" below). Remaining backend infrastructure upgrades (MySQL 5.7 → 8 → 9) are deferred until the frontend track is complete.
 
 ## PR sizing strategy
 
@@ -55,7 +56,7 @@ Use bigger PRs, but keep them coherent:
 
 This is the active track. Keep each step as its own PR.
 
-1. Replace Gulp 3 with a current build setup in a focused PR.
+1. Continue frontend dependency/runtime modernization now that the build no longer depends on Gulp 3/Laravel Elixir.
 
 ## Deferred backend infrastructure path
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,27 +1,40 @@
-var elixir = require('laravel-elixir');
+'use strict';
 
-config.assetsPath = '.';
-config.publicPath = '.';
+var gulp = require('gulp');
+var concat = require('gulp-concat');
+var sass = require('gulp-sass');
 
-elixir(function(mix) {
+var cssSources = [
+    'sass/bootstrap.scss',
+    'node_modules/owl.carousel/dist/assets/owl.carousel.min.css',
+    'node_modules/bootstrap-datepicker/dist/css/bootstrap-datepicker.min.css',
+    'node_modules/chosen-js/chosen.css',
+    'sass/flag-icon.scss',
+    'sass/style.scss'
+];
 
-    mix
-    .sass([
+var jsSources = [
+    'node_modules/jquery/dist/jquery.min.js',
+    'node_modules/bootstrap-sass/assets/javascripts/bootstrap.min.js',
+    'node_modules/owl.carousel/dist/owl.carousel.min.js',
+    'node_modules/chosen-js/chosen.jquery.js',
+    'node_modules/bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js',
+    'web/js/script.js'
+];
 
-        'bootstrap.scss',
-        '../node_modules/owl.carousel/dist/assets/owl.carousel.min.css',
-        '../node_modules/bootstrap-datepicker/dist/css/bootstrap-datepicker.min.css',
-        '../node_modules/chosen-js/chosen.css',
-        'flag-icon.scss',
-        'style.scss'
+function styles() {
+    return gulp.src(cssSources)
+        .pipe(sass().on('error', sass.logError))
+        .pipe(concat('style.css'))
+        .pipe(gulp.dest('web/css'));
+}
 
-        ],'web/css/style.css')
-    .scripts([
-        '../node_modules/jquery/dist/jquery.min.js',
-        '../node_modules/bootstrap-sass/assets/javascripts/bootstrap.min.js',
-        '../node_modules/owl.carousel/dist/owl.carousel.min.js',
-        '../node_modules/chosen-js/chosen.jquery.js',
-        '../node_modules/bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js',
-        '../web/js/script.js',
-        ],'web/js/all-scripts.js');
-});
+function scripts() {
+    return gulp.src(jsSources)
+        .pipe(concat('all-scripts.js'))
+        .pipe(gulp.dest('web/js'));
+}
+
+exports.styles = styles;
+exports.scripts = scripts;
+exports.default = gulp.parallel(styles, scripts);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "test": "node tests/frontend-smoke.js"
   },
   "devDependencies": {
-    "gulp": "^3.9.1"
+    "gulp": "^4.0.2",
+    "gulp-concat": "^2.6.1",
+    "gulp-sass": "^3.2.1"
   },
   "dependencies": {
     "bootstrap-datepicker": "^1.6.1",
@@ -13,7 +15,6 @@
     "chosen-js": "^1.5.1",
     "flag-icon-css": "^2.3.1",
     "jquery": "2.2.4",
-    "laravel-elixir": "^3.0.0",
     "material-datetime-picker": "^1.0.1",
     "owl.carousel": "^2.1.5",
     "browser-sync": "2.26.7",


### PR DESCRIPTION
Replace the legacy Laravel Elixir/Gulp 3 frontend build with a plain Gulp 4 build.