### PR TITLE
Add production Docker Compose stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,36 @@ jobs:
           curl -fsSI --max-time 10 http://localhost:8000/css/style.css
           curl -fsSI --max-time 10 http://localhost:8000/js/all-scripts.js
 
+  build-prod:
+    if: github.event_name == 'push' || github.event.pull_request.user.login == github.repository_owner
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      MYSQL_DATABASE: sportify
+      MYSQL_USER: sportify
+      MYSQL_PASSWORD: sportify
+      MYSQL_ROOT_PASSWORD: root
+      HTTP_PORT: "8080"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare Symfony parameters
+        env:
+          FOOTBALL_DATA_API_TOKEN: ${{ secrets.FOOTBALL_DATA_API_TOKEN }}
+        run: |
+          test -n "$FOOTBALL_DATA_API_TOKEN"
+          cp docker/symfony/parameters.yml app/config/parameters.yml
+          sed -i "s/football_api.token: check_the_README_file/football_api.token: '$FOOTBALL_DATA_API_TOKEN'/" app/config/parameters.yml
+
+      - name: Build Docker images
+        run: docker compose -f docker-compose.prod.yml build
+
+      - name: HTTP smoke test
+        run: |
+          docker compose -f docker-compose.prod.yml up --wait httpd
+          curl -fsSI --max-time 10 http://localhost:8080/
+          curl -fsSI --max-time 10 http://localhost:8080/css/style.css
+          curl -fsSI --max-time 10 http://localhost:8080/js/all-scripts.js

--- a/TODO.md
+++ b/TODO.md
@@ -38,6 +38,7 @@
 - Bower has been removed; frontend dependencies now install through npm.
 - Gulp 3 and Laravel Elixir have been replaced with a plain Gulp 4 build.
 - `node-sass` has been replaced with Dart Sass via `gulp-sass` 5.
+- A production Docker Compose stack (`docker-compose.prod.yml`) is separate from the dev stack, with a php-fpm + httpd runtime built from `docker/Dockerfile.prod`.
 
 ## Next steps
 
@@ -67,12 +68,11 @@ Separate the deployment stack from the local development stack. Keep `docker-com
 
 ### Backend deployment tasks
 
-1. ~~Add a production Docker Compose stack separate from the dev stack.~~ Done — `docker-compose.prod.yml` with a php-fpm + httpd runtime built from `docker/Dockerfile.prod`.
-2. Make deployment configuration environment-driven instead of requiring manual `app/config/parameters.yml` edits.
-3. Add an idempotent first-deploy/init path that waits for the database, creates/updates schema, runs `assets:install`, and clears/warms prod cache.
-4. Decide how first admin creation should work now that FOSUserBundle is gone.
-5. Add an app-owned scheduled command that sends users' predictions to the configured Telegram chat shortly after each match starts, without hardcoded secrets. This is separate from the existing Telegram result notification sent after matches end and scores are updated.
-6. Document required env vars, first deployment, upgrades, scheduled commands, and smoke checks.
+1. Make deployment configuration environment-driven instead of requiring manual `app/config/parameters.yml` edits.
+2. Add an idempotent first-deploy/init path that waits for the database, creates/updates schema, runs `assets:install`, and clears/warms prod cache.
+3. Decide how first admin creation should work now that FOSUserBundle is gone.
+4. Add an app-owned scheduled command that sends users' predictions to the configured Telegram chat shortly after each match starts, without hardcoded secrets. This is separate from the existing Telegram result notification sent after matches end and scores are updated.
+5. Document required env vars, first deployment, upgrades, scheduled commands, and smoke checks.
 
 ### Frontend deployment tasks
 

--- a/TODO.md
+++ b/TODO.md
@@ -67,9 +67,9 @@ Separate the deployment stack from the local development stack. Keep `docker-com
 
 ### Backend deployment tasks
 
-1. Add a production Docker Compose stack separate from the dev stack.
+1. ~~Add a production Docker Compose stack separate from the dev stack.~~ Done — `docker-compose.prod.yml` with a php-fpm + httpd runtime built from `docker/Dockerfile.prod`.
 2. Make deployment configuration environment-driven instead of requiring manual `app/config/parameters.yml` edits.
-3. Add an idempotent first-deploy/init path that waits for the database, creates/updates schema, and clears/warms prod cache.
+3. Add an idempotent first-deploy/init path that waits for the database, creates/updates schema, runs `assets:install`, and clears/warms prod cache.
 4. Decide how first admin creation should work now that FOSUserBundle is gone.
 5. Add an app-owned scheduled command that sends users' predictions to the configured Telegram chat shortly after each match starts, without hardcoded secrets. This is separate from the existing Telegram result notification sent after matches end and scores are updated.
 6. Document required env vars, first deployment, upgrades, scheduled commands, and smoke checks.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,44 @@
+services:
+  php:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.prod
+      target: php
+    environment:
+      SYMFONY_ENV: prod
+    depends_on:
+      db:
+        condition: service_healthy
+    expose:
+      - "9000"
+    restart: unless-stopped
+
+  httpd:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.prod
+      target: httpd
+    depends_on:
+      - php
+    ports:
+      - "${HTTP_PORT:-8080}:80"
+    restart: unless-stopped
+
+  db:
+    image: mysql:5.7
+    environment:
+      MYSQL_DATABASE: ${MYSQL_DATABASE:?set MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER:?set MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:?set MYSQL_PASSWORD}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?set MYSQL_ROOT_PASSWORD}
+    volumes:
+      - db-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-P", "3306", "-u${MYSQL_USER}", "-p${MYSQL_PASSWORD}"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    restart: unless-stopped
+
+volumes:
+  db-data:

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -1,0 +1,87 @@
+# syntax=docker/dockerfile:1
+#
+# Production multi-stage build. Two targets are exposed:
+#   * php   — php-fpm runtime with vendor and source baked in.
+#   * httpd — Apache runtime that serves web/ and proxies PHP to php-fpm.
+#
+# app/config/parameters.yml must exist before building (the deployment
+# config track will replace this with env-driven config).
+
+FROM composer:2.2.25 AS composer-bin
+
+# Stage 1: install PHP dependencies without dev packages.
+FROM php:8.5-cli-bookworm AS composer-build
+COPY --from=composer-bin /usr/bin/composer /usr/local/bin/composer
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        unzip \
+        zlib1g-dev \
+        libicu-dev \
+        libcurl4-openssl-dev \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libpng-dev \
+        libzip-dev \
+        libonig-dev \
+    ; \
+    docker-php-ext-configure gd --with-freetype --with-jpeg; \
+    docker-php-ext-install -j"$(nproc)" curl gd intl mbstring pdo_mysql zip; \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+ENV COMPOSER_ALLOW_SUPERUSER=1 \
+    COMPOSER_MEMORY_LIMIT=-1 \
+    COMPOSER_FUND=0 \
+    SYMFONY_ENV=prod
+COPY composer.json composer.lock ./
+COPY app app
+COPY src src
+COPY web web
+COPY bin bin
+RUN composer install --no-dev --no-interaction --no-progress --optimize-autoloader --no-scripts
+
+# Stage 2: build frontend assets.
+FROM node:26-trixie AS asset-build
+RUN npm install -g gulp-cli@2.3.0
+WORKDIR /app
+COPY package.json package-lock.json gulpfile.js ./
+COPY sass sass
+COPY web web
+RUN npm install --no-audit --no-fund
+RUN gulp
+
+# Stage 3: php-fpm runtime.
+FROM php:8.5-fpm-bookworm AS php
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        libicu-dev \
+        libcurl4-openssl-dev \
+        libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libpng-dev \
+        libzip-dev \
+        libonig-dev \
+    ; \
+    docker-php-ext-configure gd --with-freetype --with-jpeg; \
+    docker-php-ext-install -j"$(nproc)" curl gd intl mbstring pdo_mysql zip; \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --chown=www-data:www-data --from=composer-build /app /app
+COPY --chown=www-data:www-data --from=asset-build /app/web/css /app/web/css
+COPY --chown=www-data:www-data --from=asset-build /app/web/js /app/web/js
+RUN set -eux; \
+    mkdir -p var/cache var/logs var/sessions web/bundles; \
+    chown -R www-data:www-data var web/bundles
+USER www-data
+EXPOSE 9000
+CMD ["php-fpm"]
+
+# Stage 4: Apache httpd runtime.
+FROM httpd:2.4 AS httpd
+COPY docker/httpd/httpd.prod.conf /usr/local/apache2/conf/httpd.conf
+COPY --from=php /app/web /app/web
+EXPOSE 80

--- a/docker/README.md
+++ b/docker/README.md
@@ -37,3 +37,31 @@ docker compose run --rm php vendor/bin/simple-phpunit --testsuite 'Project Test 
 ```
 
 The upgrade milestone is to keep these smoke checks passing after each step.
+
+## Production stack
+
+`docker-compose.prod.yml` is a separate stack intended for deployments. It builds two
+runtime images from `docker/Dockerfile.prod` — `php` (php-fpm) and `httpd` — with the
+application source, vendor, and built frontend assets baked in. There is no bind
+mount and no Node/Composer in the runtime images.
+
+Before building, place a production `app/config/parameters.yml` on the host (this file
+is gitignored). Making this env-driven is a separate, follow-up step on the deployment
+track.
+
+Database credentials and the host port come from environment variables; the stack
+will fail to start if they are missing:
+
+```sh
+export MYSQL_DATABASE=sportify
+export MYSQL_USER=sportify
+export MYSQL_PASSWORD=...
+export MYSQL_ROOT_PASSWORD=...
+export HTTP_PORT=8080
+
+docker compose -f docker-compose.prod.yml build
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Initial schema creation, prod cache warm, and operational documentation are tracked
+as follow-up tasks in `TODO.md`.

--- a/docker/httpd/httpd.prod.conf
+++ b/docker/httpd/httpd.prod.conf
@@ -1,0 +1,42 @@
+ServerRoot "/usr/local/apache2"
+Listen 80
+ServerName localhost
+
+LoadModule mpm_event_module modules/mod_mpm_event.so
+LoadModule authz_core_module modules/mod_authz_core.so
+LoadModule authz_host_module modules/mod_authz_host.so
+LoadModule log_config_module modules/mod_log_config.so
+LoadModule mime_module modules/mod_mime.so
+LoadModule dir_module modules/mod_dir.so
+LoadModule unixd_module modules/mod_unixd.so
+LoadModule rewrite_module modules/mod_rewrite.so
+LoadModule proxy_module modules/mod_proxy.so
+LoadModule proxy_fcgi_module modules/mod_proxy_fcgi.so
+
+User daemon
+Group daemon
+
+ErrorLog /proc/self/fd/2
+TransferLog /proc/self/fd/1
+LogLevel warn
+
+TypesConfig conf/mime.types
+
+DocumentRoot "/app/web"
+DirectoryIndex app.php
+
+<Directory "/app/web">
+    Options FollowSymLinks
+    AllowOverride None
+    Require all granted
+</Directory>
+
+<FilesMatch \.php$>
+    SetHandler "proxy:fcgi://php:9000"
+</FilesMatch>
+
+RewriteEngine On
+
+# Serve existing files directly from httpd; otherwise route through app.php.
+RewriteCond "%{DOCUMENT_ROOT}%{REQUEST_URI}" !-f
+RewriteRule ^ /app.php [QSA,L]


### PR DESCRIPTION
Adds `docker-compose.prod.yml` and a multistage `docker/Dockerfile.prod` exposing `php` (php-fpm) and `httpd` targets, with vendor and built frontend assets baked into the runtime images and no bind mounts. Env-driven config, the first-deploy init/migrations path, and `assets:install` are the remaining deployment tasks in TODO.md.