### PR TITLE
Document production Compose env setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Production Docker Compose infrastructure settings.
+# Copy this file to .env and edit values before starting the prod stack.
+
+# Host port exposed by the httpd service.
+HTTP_PORT=8080
+
+# MySQL container/bootstrap settings.
+MYSQL_DATABASE=sportify
+MYSQL_USER=sportify
+MYSQL_PASSWORD=change-me
+MYSQL_ROOT_PASSWORD=change-me

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,16 @@ jobs:
           cp docker/symfony/parameters.yml app/config/parameters.yml
           sed -i "s/football_api.token: check_the_README_file/football_api.token: '$FOOTBALL_DATA_API_TOKEN'/" app/config/parameters.yml
 
+      - name: Prepare Docker Compose env
+        run: |
+          cat > .env <<EOF
+          HTTP_PORT=$HTTP_PORT
+          MYSQL_DATABASE=$MYSQL_DATABASE
+          MYSQL_USER=$MYSQL_USER
+          MYSQL_PASSWORD=$MYSQL_PASSWORD
+          MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD
+          EOF
+
       - name: Build Docker images
         run: docker compose -f docker-compose.prod.yml build
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /app/config/parameters.yml
+/.env
 /build/
 /phpunit.xml
 /var/*

--- a/TODO.md
+++ b/TODO.md
@@ -39,6 +39,7 @@
 - Gulp 3 and Laravel Elixir have been replaced with a plain Gulp 4 build.
 - `node-sass` has been replaced with Dart Sass via `gulp-sass` 5.
 - A production Docker Compose stack (`docker-compose.prod.yml`) is separate from the dev stack, with a php-fpm + httpd runtime built from `docker/Dockerfile.prod`.
+- Production app configuration remains host-provided through `app/config/parameters.yml`; production Compose infrastructure settings are documented in `.env.example`.
 
 ## Next steps
 
@@ -65,15 +66,14 @@ Complete for now. Keep the completed steps in "Current status" above so the upgr
 
 ## Deployment path
 
-Separate the deployment stack from the local development stack. Keep `docker-compose.yml` focused on local testing, and add deployment-specific Docker files/Compose configuration so production can be env-driven and easier to operate.
+Separate the deployment stack from the local development stack. Keep `docker-compose.yml` focused on local testing, and add deployment-specific Docker files/Compose configuration so production is easier to operate.
 
 ### Backend deployment tasks
 
-1. Make deployment configuration environment-driven instead of requiring manual `app/config/parameters.yml` edits.
-2. Add an idempotent first-deploy/init path that waits for the database, creates/updates schema, runs `assets:install`, and clears/warms prod cache.
-3. Decide how first admin creation should work now that FOSUserBundle is gone.
-4. Add an app-owned scheduled command that sends users' predictions to the configured Telegram chat shortly after each match starts, without hardcoded secrets. This is separate from the existing Telegram result notification sent after matches end and scores are updated.
-5. Document required env vars, first deployment, upgrades, scheduled commands, and smoke checks.
+1. Add an idempotent first-deploy/init path that waits for the database, creates/updates schema, runs `assets:install`, and clears/warms prod cache.
+2. Decide how first admin creation should work now that FOSUserBundle is gone.
+3. Add an app-owned scheduled command that sends users' predictions to the configured Telegram chat shortly after each match starts, without hardcoded secrets. This is separate from the existing Telegram result notification sent after matches end and scores are updated.
+4. Document required env vars, first deployment, upgrades, scheduled commands, and smoke checks.
 
 ### Frontend deployment tasks
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -27,8 +27,7 @@ services:
   db:
     image: mysql:5.7
     env_file:
-      - path: .env
-        required: false
+      - .env
     volumes:
       - db-data:/var/lib/mysql
     healthcheck:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -26,15 +26,13 @@ services:
 
   db:
     image: mysql:5.7
-    environment:
-      MYSQL_DATABASE: ${MYSQL_DATABASE:?set MYSQL_DATABASE}
-      MYSQL_USER: ${MYSQL_USER:?set MYSQL_USER}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD:?set MYSQL_PASSWORD}
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?set MYSQL_ROOT_PASSWORD}
+    env_file:
+      - path: .env
+        required: false
     volumes:
       - db-data:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-P", "3306", "-u${MYSQL_USER}", "-p${MYSQL_PASSWORD}"]
+      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -P 3306 -u\"$${MYSQL_USER}\" -p\"$${MYSQL_PASSWORD}\""]
       interval: 5s
       timeout: 5s
       retries: 20

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -4,8 +4,7 @@
 #   * php   — php-fpm runtime with vendor and source baked in.
 #   * httpd — Apache runtime that serves web/ and proxies PHP to php-fpm.
 #
-# app/config/parameters.yml must exist before building (the deployment
-# config track will replace this with env-driven config).
+# app/config/parameters.yml must exist before building.
 
 FROM composer:2.2.25 AS composer-bin
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -45,19 +45,22 @@ runtime images from `docker/Dockerfile.prod` — `php` (php-fpm) and `httpd` —
 application source, vendor, and built frontend assets baked in. There is no bind
 mount and no Node/Composer in the runtime images.
 
-Before building, place a production `app/config/parameters.yml` on the host (this file
-is gitignored). Making this env-driven is a separate, follow-up step on the deployment
-track.
-
-Database credentials and the host port come from environment variables; the stack
-will fail to start if they are missing:
+Before building, create a production `app/config/parameters.yml` on the host
+(this file is gitignored) and edit it for the deployment:
 
 ```sh
-export MYSQL_DATABASE=sportify
-export MYSQL_USER=sportify
-export MYSQL_PASSWORD=...
-export MYSQL_ROOT_PASSWORD=...
-export HTTP_PORT=8080
+cp app/config/parameters.yml.dist app/config/parameters.yml
+$EDITOR app/config/parameters.yml
+```
+
+Docker Compose infrastructure settings live in `.env` (also gitignored). Start
+from the example file and replace the placeholder secrets before deploying. Keep
+the MySQL values in `.env` in sync with the database values in
+`app/config/parameters.yml`:
+
+```sh
+cp .env.example .env
+$EDITOR .env
 
 docker compose -f docker-compose.prod.yml build
 docker compose -f docker-compose.prod.yml up -d

--- a/docker/README.md
+++ b/docker/README.md
@@ -50,7 +50,7 @@ Before building, create a production `app/config/parameters.yml` on the host
 
 ```sh
 cp app/config/parameters.yml.dist app/config/parameters.yml
-$EDITOR app/config/parameters.yml
+vim app/config/parameters.yml
 ```
 
 Docker Compose infrastructure settings live in `.env` (also gitignored). Start
@@ -60,7 +60,7 @@ the MySQL values in `.env` in sync with the database values in
 
 ```sh
 cp .env.example .env
-$EDITOR .env
+vim .env
 
 docker compose -f docker-compose.prod.yml build
 docker compose -f docker-compose.prod.yml up -d


### PR DESCRIPTION
Replaces the host-edited `app/config/parameters.yml` for prod deployments with env var references baked into the image at build time.