### PR TITLE
Fix admin data updates flash message

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -43,6 +43,7 @@
 - Docker MySQL has been upgraded from 5.7 to 9.7, with explicit utf8mb4 server and Doctrine table defaults. Schema validation, reserved-word checks, SQL mode, and charset/collation checks are clean against MySQL 9.7.
 - Production Compose includes an idempotent `init` service that waits for the database, creates/updates schema, installs bundle assets, and clears/warms prod cache before app startup.
 - First admin creation is handled by the app-owned `sportify:user:create-admin` command.
+- Admin panel Data Updates now shows the no-updates flash message without calling the removed `session` service.
 
 ## Next steps
 
@@ -73,10 +74,9 @@ Separate the deployment stack from the local development stack. Keep `docker-com
 
 ### Backend deployment tasks
 
-1. Investigate and fix the admin panel Data Updates failure; it still occurs with a tournament configured and currently calls the removed `session` service for flash messages when no updates are applied.
-2. Add an app-owned regular-user creation command for deployments without SMTP, similar to `sportify:user:create-admin` but without admin roles.
-3. Add an app-owned scheduled command that sends users' predictions to the configured Telegram chat shortly after each match starts, without hardcoded secrets. This is separate from the existing Telegram result notification sent after matches end and scores are updated.
-4. Document required env vars, first deployment, upgrades, scheduled commands, and smoke checks.
+1. Add an app-owned regular-user creation command for deployments without SMTP, similar to `sportify:user:create-admin` but without admin roles.
+2. Add an app-owned scheduled command that sends users' predictions to the configured Telegram chat shortly after each match starts, without hardcoded secrets. This is separate from the existing Telegram result notification sent after matches end and scores are updated.
+3. Document required env vars, first deployment, upgrades, scheduled commands, and smoke checks.
 
 ### Frontend deployment tasks
 

--- a/src/Devlabs/SportifyBundle/Controller/AdminController.php
+++ b/src/Devlabs/SportifyBundle/Controller/AdminController.php
@@ -161,8 +161,10 @@ class AdminController extends AbstractController
             return $this->redirectToRoute('fos_user_security_login');
         }
 
+        $submittedApiMapping = $request->request->all('api_mapping');
+
         // redirect to admin/api_mappings page if the 'api_mapping' parameter is NOT set in the POST data
-        if (!$request->request->get('api_mapping')) {
+        if (!$submittedApiMapping) {
             return $this->redirectToRoute('admin_api_mappings');
         }
 
@@ -173,19 +175,19 @@ class AdminController extends AbstractController
         $em = $this->container->get('doctrine')->getManager();
 
         // set the ApiMapping object based on whether it's new or existing one
-        if ($request->request->get('api_mapping')['id']) {
+        if ($submittedApiMapping['id']) {
             $apiMapping = $em->getRepository(ApiMapping::class)
-                ->findOneById($request->request->get('api_mapping')['id']);
+                ->findOneById($submittedApiMapping['id']);
         } else {
             $apiMapping = new ApiMapping();
-            $apiMapping->setEntityId($request->request->get('api_mapping')['entityId']);
-            $apiMapping->setEntityType($request->request->get('api_mapping')['entityType']);
-            $apiMapping->setApiName($request->request->get('api_mapping')['apiName']);
+            $apiMapping->setEntityId($submittedApiMapping['entityId']);
+            $apiMapping->setEntityType($submittedApiMapping['entityType']);
+            $apiMapping->setApiName($submittedApiMapping['apiName']);
         }
 
-        $apiMapping->setApiObjectId($request->request->get('api_mapping')['apiObjectId']);
+        $apiMapping->setApiObjectId($submittedApiMapping['apiObjectId']);
 
-        $buttonAction = $request->request->get('api_mapping')['action'];
+        $buttonAction = $submittedApiMapping['action'];
 
         $form = $adminHelper->createApiMappingForm($apiMapping, $buttonAction);
         $form->handleRequest($request);
@@ -241,8 +243,10 @@ class AdminController extends AbstractController
             return $this->redirectToRoute('fos_user_security_login');
         }
 
+        $submittedTournament = $request->request->all('tournament_entity');
+
         // redirect to admin/tournaments page if the 'tournament_entity' parameter is NOT set in the POST data
-        if (!$request->request->get('tournament_entity')) {
+        if (!$submittedTournament) {
             return $this->redirectToRoute('admin_tournaments');
         }
 
@@ -253,22 +257,22 @@ class AdminController extends AbstractController
         $em = $this->container->get('doctrine')->getManager();
 
         // set the tournament object based on whether it's new or existing one
-        if ($request->request->get('tournament_entity')['id']) {
+        if ($submittedTournament['id']) {
             $tournament = $em->getRepository(Tournament::class)
-                ->findOneById($request->request->get('tournament_entity')['id']);
+                ->findOneById($submittedTournament['id']);
         } else {
             $tournament = new Tournament();
         }
 
         // create DateTime object from the datetime string in the POST request
-        $startDate = \DateTime::createFromFormat('Y-m-d', $request->request->get('tournament_entity')['startDate']);
-        $endDate = \DateTime::createFromFormat('Y-m-d', $request->request->get('tournament_entity')['endDate']);
+        $startDate = \DateTime::createFromFormat('Y-m-d', $submittedTournament['startDate']);
+        $endDate = \DateTime::createFromFormat('Y-m-d', $submittedTournament['endDate']);
 
-        $tournament->setName($request->request->get('tournament_entity')['name']);
+        $tournament->setName($submittedTournament['name']);
         $tournament->setStartDate($startDate);
         $tournament->setEndDate($endDate);
 
-        $buttonAction = $request->request->get('tournament_entity')['action'];
+        $buttonAction = $submittedTournament['action'];
 //        $formInputData = $adminHelper->getTournamentFormInputData($tournament);
 
         $form = $adminHelper->createTournamentForm($tournament, $buttonAction);
@@ -325,8 +329,10 @@ class AdminController extends AbstractController
             return $this->redirectToRoute('fos_user_security_login');
         }
 
+        $submittedTeam = $request->request->all('team_entity');
+
         // redirect to admin/teams page if the 'team_entity' parameter is NOT set in the POST data
-        if (!$request->request->get('team_entity')) {
+        if (!$submittedTeam) {
             return $this->redirectToRoute('admin_teams');
         }
 
@@ -337,16 +343,16 @@ class AdminController extends AbstractController
         $em = $this->container->get('doctrine')->getManager();
 
         // set the team object based on whether it's new or existing one
-        if ($request->request->get('team_entity')['id']) {
+        if ($submittedTeam['id']) {
             $team = $em->getRepository(Team::class)
-                ->findOneById($request->request->get('team_entity')['id']);
+                ->findOneById($submittedTeam['id']);
         } else {
             $team = new Team();
         }
 
-        $team->setName($request->request->get('team_entity')['name']);
+        $team->setName($submittedTeam['name']);
 
-        $buttonAction = $request->request->get('team_entity')['action'];
+        $buttonAction = $submittedTeam['action'];
 
         $form = $adminHelper->createTeamForm($team, $buttonAction);
         $form->handleRequest($request);
@@ -455,8 +461,10 @@ class AdminController extends AbstractController
             return $this->redirectToRoute('fos_user_security_login');
         }
 
+        $submittedMatch = $request->request->all('match_entity');
+
         // redirect to admin/matches page if the 'match_entity' parameter is NOT set in the POST data
-        if (!$request->request->get('match_entity')) {
+        if (!$submittedMatch) {
             return $this->redirectToRoute('admin_matches');
         }
 
@@ -472,9 +480,9 @@ class AdminController extends AbstractController
             ->findOneById($tournament_id);
 
         // set the match object based on whether it's new or existing one
-        if ($request->request->get('match_entity')['id']) {
+        if ($submittedMatch['id']) {
             $match = $em->getRepository(MatchEntity::class)
-                ->findOneById($request->request->get('match_entity')['id']);
+                ->findOneById($submittedMatch['id']);
         } else {
             $match = new MatchEntity();
             $match->setTournamentId($tournament);
@@ -482,12 +490,12 @@ class AdminController extends AbstractController
 
         // prep data for use in Match object setter methods
         $homeTeam = $em->getRepository(Team::class)
-            ->findOneById($request->request->get('match_entity')['homeTeamId']['id']);
+            ->findOneById($submittedMatch['homeTeamId']['id']);
         $awayTeam = $em->getRepository(Team::class)
-            ->findOneById($request->request->get('match_entity')['awayTeamId']['id']);
-        $datetime = \DateTime::createFromFormat('Y-m-d H:i', $request->request->get('match_entity')['datetime']);
-        $notificationSent = (array_key_exists('notificationSent', $request->request->get('match_entity')))
-            ? $request->request->get('match_entity')['notificationSent']
+            ->findOneById($submittedMatch['awayTeamId']['id']);
+        $datetime = \DateTime::createFromFormat('Y-m-d H:i', $submittedMatch['datetime']);
+        $notificationSent = (array_key_exists('notificationSent', $submittedMatch))
+            ? $submittedMatch['notificationSent']
             : 0;
 
         $match->setDatetime($datetime);
@@ -495,13 +503,13 @@ class AdminController extends AbstractController
         $match->setAwayTeamId($awayTeam);
         $match->setNotificationSent($notificationSent);
 
-        if (($request->request->get('match_entity')['homeGoals'] !== null) &&
-            ($request->request->get('match_entity')['awayGoals'] !== null)) {
-            $match->setHomeGoals($request->request->get('match_entity')['homeGoals']);
-            $match->setAwayGoals($request->request->get('match_entity')['awayGoals']);
+        if (($submittedMatch['homeGoals'] !== null) &&
+            ($submittedMatch['awayGoals'] !== null)) {
+            $match->setHomeGoals($submittedMatch['homeGoals']);
+            $match->setAwayGoals($submittedMatch['awayGoals']);
         }
 
-        $buttonAction = $request->request->get('match_entity')['action'];
+        $buttonAction = $submittedMatch['action'];
         $formInputData = $adminHelper->getMatchFormInputData($match);
 
         $form = $adminHelper->createMatchForm($urlParams, $match, $buttonAction, $formInputData);

--- a/src/Devlabs/SportifyBundle/Controller/MatchesController.php
+++ b/src/Devlabs/SportifyBundle/Controller/MatchesController.php
@@ -141,15 +141,15 @@ class MatchesController extends AbstractController
             return $this->redirectToRoute('fos_user_security_login');
         }
 
+        $formsArray = $request->request->all('matches');
+
         // redirect to the matches main page if the 'matches' array is NOT set in the POST data
-        if (!$request->request->get('matches')) {
+        if (!$formsArray) {
             return $this->redirectToRoute('matches_index');
         }
 
         // Get an instance of the Entity Manager
         $em = $this->container->get('doctrine')->getManager();
-
-        $formsArray = $request->request->get('matches');
 
         foreach ($formsArray as $submittedForm) {
             $match = $em->getRepository(MatchEntity::class)

--- a/src/Devlabs/SportifyBundle/Resources/config/services.yml
+++ b/src/Devlabs/SportifyBundle/Resources/config/services.yml
@@ -71,7 +71,7 @@ services:
 
     app.admin.helper:
         class: Devlabs\SportifyBundle\Services\ControllerHelpers\AdminHelper
-        arguments: ['@service_container', '@doctrine.orm.entity_manager']
+        arguments: ['@service_container', '@doctrine.orm.entity_manager', '@request_stack']
 
     app.matches.helper:
         class: Devlabs\SportifyBundle\Services\ControllerHelpers\MatchesHelper

--- a/src/Devlabs/SportifyBundle/Services/ControllerHelpers/AdminHelper.php
+++ b/src/Devlabs/SportifyBundle/Services/ControllerHelpers/AdminHelper.php
@@ -4,6 +4,7 @@ namespace Devlabs\SportifyBundle\Services\ControllerHelpers;
 
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Doctrine\ORM\EntityManager;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -28,11 +29,13 @@ class AdminHelper
     use ContainerAwareTrait;
 
     private $em;
+    private $requestStack;
 
-    public function __construct(ContainerInterface $container, EntityManager $entityManager)
+    public function __construct(ContainerInterface $container, EntityManager $entityManager, RequestStack $requestStack)
     {
         $this->container = $container;
         $this->em = $entityManager;
+        $this->requestStack = $requestStack;
     }
 
     /**
@@ -121,7 +124,7 @@ class AdminHelper
 
         if ($msgText === '') $msgText = 'No fixtures/results added or updated.';
 
-        $this->container->get('session')->getFlashBag()->add('message', $msgText);
+        $this->requestStack->getSession()->getFlashBag()->add('message', $msgText);
     }
 
     /**

--- a/tests/Functional/AdminDataUpdatesTest.php
+++ b/tests/Functional/AdminDataUpdatesTest.php
@@ -6,6 +6,25 @@ use Devlabs\SportifyBundle\Entity\Tournament;
 
 class AdminDataUpdatesTest extends FunctionalTestCase
 {
+    public function testAdminTournamentSubmitAcceptsArrayPayload()
+    {
+        $this->createUser('admin_tournament_create', 'testpass', true, array('ROLE_ADMIN'));
+        $this->login('admin_tournament_create@example.com', 'testpass');
+        $this->assertTrue($this->client->getResponse()->isRedirect());
+
+        $this->client->request('POST', '/admin/tournaments/modify', array(
+            'tournament_entity' => array(
+                'id' => '',
+                'action' => 'CREATE',
+                'name' => 'Browser Verify Cup',
+                'startDate' => '2026-01-01',
+                'endDate' => '2026-12-31',
+            ),
+        ));
+
+        $this->assertTrue($this->client->getResponse()->isRedirect('/admin/tournaments'));
+    }
+
     public function testAdminDataUpdatesShowsFlashWhenNoUpdatesAreApplied()
     {
         $this->createUser('admin_data_updates', 'testpass', true, array('ROLE_ADMIN'));

--- a/tests/Functional/AdminDataUpdatesTest.php
+++ b/tests/Functional/AdminDataUpdatesTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Functional;
+
+use Devlabs\SportifyBundle\Entity\Tournament;
+
+class AdminDataUpdatesTest extends FunctionalTestCase
+{
+    public function testAdminDataUpdatesShowsFlashWhenNoUpdatesAreApplied()
+    {
+        $this->createUser('admin_data_updates', 'testpass', true, array('ROLE_ADMIN'));
+        $tournament = new Tournament();
+        $tournament->setName('No Updates Cup');
+        $tournament->setStartDate(new \DateTime('-1 month'));
+        $tournament->setEndDate(new \DateTime('+1 month'));
+        $this->em->persist($tournament);
+        $this->em->flush();
+
+        $this->login('admin_data_updates@example.com', 'testpass');
+        $this->assertTrue($this->client->getResponse()->isRedirect());
+
+        $crawler = $this->client->request('GET', '/admin/data_updates/match_results');
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+
+        $this->client->submit($crawler->selectButton('Update')->form());
+        $this->assertTrue($this->client->getResponse()->isRedirect('/admin/data_updates'));
+
+        $crawler = $this->client->followRedirect();
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->assertStringContainsString('No fixtures/results added or updated.', $crawler->filter('body')->text());
+    }
+}


### PR DESCRIPTION
Fix admin Data Updates no-op submissions so they flash a message without requiring the removed session service.