### PR TITLE
Use configured Telegram service for data updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Best practice is to use a transactional mail service, like Mailgun, Amazon SES, 
  `football_api.token` - you can get one free from [football-data.org](http://www.football-data.org/register). If you use the service for a longer time, consider [donating](http://api.football-data.org/about) :)  
 ` slack.url, slack.channel` - Generate them in [Slack](https://slack.com/apps/A0F7XDUAZ-incoming-webhooks) in order to get notifications.  
 `telegram.bot_token, telegram.chat_id` - Configure these to send scheduled Telegram notifications.
+`telegram.pin_messages` - Set to `false` to disable pinning Telegram data update notifications. Defaults to `true`.
 `secret` - Symfony variable - generate it by going [here](http://nux.net/secret) or running in shell `openssl rand -hex 20`
 
 **N.B.**

--- a/TODO.md
+++ b/TODO.md
@@ -48,6 +48,7 @@
 - Production deployment documentation covers required local config files, first deployment, upgrades, scheduled commands, and smoke checks.
 - Production Docker builds frontend assets in a Node build stage, copies generated `web/css` and `web/js` assets into the php-fpm/httpd runtime images, and keeps Node/npm out of the final runtime images.
 - Submitted predictions can be sent to the configured Telegram chat shortly after kickoff with `sportify:telegram:send-predictions`.
+- Data update Telegram notifications use the app-owned Telegram service/config instead of legacy hardcoded send/pin URLs; sent messages are pinned by default and can be disabled with `telegram.pin_messages: false`.
 
 ## Next steps
 
@@ -78,7 +79,7 @@ Separate the deployment stack from the local development stack. Keep `docker-com
 
 ### Backend deployment tasks
 
-- Remove the legacy hardcoded Telegram send/pin block from `src/Devlabs/SportifyBundle/Command/DataUpdateCommand.php`; replace it with the app-owned Telegram service/config if result update Telegram notifications are still needed.
+Complete for now.
 
 ### Frontend deployment tasks
 

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -31,6 +31,8 @@ parameters:
     telegram.bot_token: check_the_README_file
     # Telegram chat id for scheduled notifications
     telegram.chat_id: check_the_README_file
+    # Pin Telegram data update notifications after sending
+    telegram.pin_messages: true
 
     # sportify API params used for generating tokens
     sportify_api.client_id:     ~

--- a/docker/symfony/parameters.yml
+++ b/docker/symfony/parameters.yml
@@ -15,6 +15,7 @@ parameters:
     slack.channel: check_the_README_file
     telegram.bot_token: check_the_README_file
     telegram.chat_id: check_the_README_file
+    telegram.pin_messages: true
 
     sportify_api.client_id: ~
     sportify_api.client_secret: ~

--- a/src/Devlabs/SportifyBundle/Command/DataUpdateCommand.php
+++ b/src/Devlabs/SportifyBundle/Command/DataUpdateCommand.php
@@ -110,14 +110,16 @@ class DataUpdateCommand extends Command
             $this->container->get('app.slack')->setText($msgText)->post();
 
             $logText = $logText . "\n" . $msgText . "\n";
-            $botToken = "your_bot_token";
-            $website = "https://api.telegram.org/bot" . $botToken;
-            $channelId = "@your_channel_id";
-            $url = $website."/sendmessage?chat_id=".$channelId."&text=".urlencode($logText);
-            $telegram_result = (json_decode(file_get_contents($url), true));
-            $message_id = $telegram_result["result"]["message_id"];
-            $url = $website."/pinChatMessage?chat_id=".$channelId."&message_id=".$message_id;
-            file_get_contents($url);
+
+            $telegram = $this->container->get('app.telegram');
+            $telegramResponse = $telegram->sendMessage($logText);
+            if ($telegramResponse->getStatusCode() >= 200 && $telegramResponse->getStatusCode() < 300) {
+                $telegramResult = json_decode((string) $telegramResponse->getBody(), true);
+
+                if ($this->shouldPinTelegramMessages() && isset($telegramResult['result']['message_id'])) {
+                    $telegram->pinMessage($telegramResult['result']['message_id']);
+                }
+            }
         } else {
             $logText = $logText . "\n" . 'No fixtures/results added or updated.' . "\n";
         }
@@ -125,5 +127,14 @@ class DataUpdateCommand extends Command
         $output->writeln($logText);
 
         return 0;
+    }
+
+    private function shouldPinTelegramMessages()
+    {
+        if (!$this->container->hasParameter('telegram.pin_messages')) {
+            return true;
+        }
+
+        return filter_var($this->container->getParameter('telegram.pin_messages'), FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/src/Devlabs/SportifyBundle/Services/Telegram.php
+++ b/src/Devlabs/SportifyBundle/Services/Telegram.php
@@ -33,16 +33,8 @@ class Telegram
      */
     public function sendMessage($text)
     {
-        $env = $this->container->get('kernel')->getEnvironment();
-
-        if ($env !== 'prod' || !$this->botToken || !$this->chatId || $this->botToken === 'check_the_README_file' || $this->chatId === 'check_the_README_file') {
-            return new Response(
-                400,
-                array(),
-                null,
-                '1.1',
-                'Env is not PROD or Telegram config is missing'
-            );
+        if (!$this->isEnabled()) {
+            return $this->disabledResponse();
         }
 
         try {
@@ -61,5 +53,53 @@ class Telegram
         } catch (RequestException $e) {
             return $e->getResponse() ?: new Response(500);
         }
+    }
+
+    /**
+     * Pin a Telegram message.
+     */
+    public function pinMessage($messageId)
+    {
+        if (!$this->isEnabled()) {
+            return $this->disabledResponse();
+        }
+
+        try {
+            return $this->httpClient->post(
+                'https://api.telegram.org/bot'.$this->botToken.'/pinChatMessage',
+                array(
+                    'form_params' => array(
+                        'chat_id' => $this->chatId,
+                        'message_id' => $messageId,
+                    ),
+                    'allow_redirects' => false,
+                    'timeout' => 5,
+                )
+            );
+        } catch (RequestException $e) {
+            return $e->getResponse() ?: new Response(500);
+        }
+    }
+
+    private function isEnabled()
+    {
+        $env = $this->container->get('kernel')->getEnvironment();
+
+        return $env === 'prod'
+            && $this->botToken
+            && $this->chatId
+            && $this->botToken !== 'check_the_README_file'
+            && $this->chatId !== 'check_the_README_file';
+    }
+
+    private function disabledResponse()
+    {
+        return new Response(
+            400,
+            array(),
+            null,
+            '1.1',
+            'Env is not PROD or Telegram config is missing'
+        );
     }
 }

--- a/tests/Unit/DataUpdateCommandTest.php
+++ b/tests/Unit/DataUpdateCommandTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Unit;
+
+use Devlabs\SportifyBundle\Command\DataUpdateCommand;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\Container;
+
+class DataUpdateCommandTest extends TestCase
+{
+    public function testSendsFixtureUpdateNotificationsThroughConfiguredServices()
+    {
+        $container = new Container();
+        $slack = new FakeDataUpdateSlack();
+        $telegram = new FakeDataUpdateTelegram();
+
+        $this->configureContainer($container, $slack, $telegram);
+
+        $tester = new CommandTester(new DataUpdateCommand($container));
+        $tester->execute(array(
+            'type' => 'matches-fixtures',
+            'days' => 3,
+        ));
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertSame('Match fixtures added for next 3 days. 2 fixture(s) added.', $slack->text);
+        $this->assertCount(1, $telegram->messages);
+        $this->assertStringContainsString($slack->text, $telegram->messages[0]);
+        $this->assertSame(array(321), $telegram->pinnedMessageIds);
+    }
+
+    public function testCanDisableTelegramMessagePinning()
+    {
+        $container = new Container();
+        $slack = new FakeDataUpdateSlack();
+        $telegram = new FakeDataUpdateTelegram();
+
+        $this->configureContainer($container, $slack, $telegram);
+        $container->setParameter('telegram.pin_messages', false);
+
+        $tester = new CommandTester(new DataUpdateCommand($container));
+        $tester->execute(array(
+            'type' => 'matches-fixtures',
+            'days' => 3,
+        ));
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertCount(1, $telegram->messages);
+        $this->assertSame(array(), $telegram->pinnedMessageIds);
+    }
+
+    private function configureContainer(Container $container, FakeDataUpdateSlack $slack, FakeDataUpdateTelegram $telegram)
+    {
+        $container->set('app.data_updates.manager', new FakeDataUpdatesManager());
+        $container->set('app.slack', $slack);
+        $container->set('app.telegram', $telegram);
+    }
+}
+
+class FakeDataUpdatesManager
+{
+    public function updateFixtures($dateFrom, $dateTo)
+    {
+        return array(
+            'total_added' => 2,
+            'total_updated' => 0,
+        );
+    }
+}
+
+class FakeDataUpdateSlack
+{
+    public $text;
+
+    public function setText($text)
+    {
+        $this->text = $text;
+
+        return $this;
+    }
+
+    public function post()
+    {
+    }
+}
+
+class FakeDataUpdateTelegram
+{
+    public $messages = array();
+    public $pinnedMessageIds = array();
+
+    public function sendMessage($text)
+    {
+        $this->messages[] = $text;
+
+        return new Response(200, array(), json_encode(array(
+            'result' => array(
+                'message_id' => 321,
+            ),
+        )));
+    }
+
+    public function pinMessage($messageId)
+    {
+        $this->pinnedMessageIds[] = $messageId;
+
+        return new Response(200);
+    }
+}


### PR DESCRIPTION
Removes the legacy hardcoded Telegram send/pin URLs from data updates and routes notifications through the configured Telegram service.