### PR TITLE
Adjust probability bonus rounding

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,7 +37,7 @@
 - Admin panel Scoring defaults has a cleaner centered form layout.
 - Submitted predictions can be sent to the configured Telegram chat shortly after kickoff with `sportify:telegram:send-predictions`.
 - Data update Telegram notifications use the app-owned Telegram service/config instead of legacy hardcoded send/pin URLs. Sent messages are pinned by default and can be disabled with `telegram.pin_messages: false`.
-- Probability-weighted scoring v1 is implemented with match scoring snapshots, stored prediction scoring breakdowns, and exact-prediction percentages based on scored results.
+- Probability-weighted scoring v1 is implemented with match scoring snapshots, stored prediction scoring breakdowns, exact-prediction percentages based on scored results, and floor-based underdog bonus rounding.
 - Football-Data integration uses v4, including the v4 teams/fixtures parser fields.
 - Upcoming fixture import uses `football-data.org` plus The Odds API snapshots and skips fixtures when complete odds are unavailable.
 - The prediction page shows probability snapshots, probability bonus chips, and points available for each outcome.
@@ -54,15 +54,6 @@ Current product task:
   - [x] Run the existing days-based `sportify:data:update matches-fixtures` command locally once the token is configured.
   - [x] Confirm whether complete home/draw/away odds snapshots are available for those matches and whether Sportify can normalize/store them.
   - Local result: first fixture dates imported with complete normalized home/draw/away snapshots totaling 100%; the 12-day command window also imported the next available June 13 fixtures.
-
-Planned product follow-up:
-
-- [ ] Revisit probability bonus rounding in a separate PR.
-  - Current `ceil((50 - p) * cap / 50)` gives a bonus for near-coin-flip underdogs such as 49%, which may be too generous.
-  - Consider switching to floor-based rounding so small underdogs do not receive bonus points.
-  - Preferred candidate formula: if `p_percent < 50`, `floor((50 - p_percent) * cap / 49)`, capped to `cap`; otherwise `0`.
-  - This keeps 49% at `+0`, still rewards real underdogs, and allows extreme long shots near 1% to reach the full cap.
-  - Update scoring tests, prediction-page display tests, and Telegram scoring/message expectations in the same PR.
 
 Bundle-structure cleanup is optional, low-urgency technical debt. It is not a current upgrade blocker and should not displace product work or bug fixes. Do not start coding it unless the user explicitly wants to continue structural cleanup and confirms a narrow scope.
 

--- a/src/Devlabs/SportifyBundle/Entity/MatchEntity.php
+++ b/src/Devlabs/SportifyBundle/Entity/MatchEntity.php
@@ -249,7 +249,7 @@ class MatchEntity
             return 0;
         }
 
-        return min($this->baseExactPoints, intdiv(((50 - $probability) * $this->baseExactPoints) + 49, 50));
+        return min($this->baseExactPoints, intdiv((50 - $probability) * $this->baseExactPoints, 49));
     }
 
     public function getOutcomePointsForOutcome($outcome)

--- a/src/Devlabs/SportifyBundle/Services/PredictionScorer.php
+++ b/src/Devlabs/SportifyBundle/Services/PredictionScorer.php
@@ -34,7 +34,7 @@ class PredictionScorer
         }
 
         $cap = $match->getBaseExactPoints();
-        $bonus = intdiv(((50 - $probability) * $cap) + 49, 50);
+        $bonus = intdiv((50 - $probability) * $cap, 49);
 
         return min($cap, $bonus);
     }

--- a/tests/Functional/AdminPredictionFlowTest.php
+++ b/tests/Functional/AdminPredictionFlowTest.php
@@ -35,7 +35,7 @@ class AdminPredictionFlowTest extends FunctionalTestCase
         $crawler = $this->client->request('GET', '/matches');
         $this->assertTrue($this->client->getResponse()->isSuccessful());
         $this->assertStringContainsString('Home 45% | Draw 30% | Away 25%', $crawler->text());
-        $this->assertStringContainsString('Points: Home 3/6 | Draw 4/7 | Away 5/8', $crawler->text());
+        $this->assertStringContainsString('Points: Home 2/5 | Draw 4/7 | Away 4/7', $crawler->text());
         $this->assertSame(3, $crawler->filter('.probability-bonus-chip')->count());
 
         $form = $crawler->filter('button.match-btn')->form(array(

--- a/tests/Unit/DataUpdateCommandTest.php
+++ b/tests/Unit/DataUpdateCommandTest.php
@@ -81,12 +81,12 @@ class DataUpdateCommandTest extends TestCase
         $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
         $this->assertStringContainsString('Result Cup', $telegram->messages[0]);
         $this->assertStringContainsString('Home FC 2-1 Away FC', $telegram->messages[0]);
-        $this->assertStringContainsString('Probabilities: home 10%, draw 25%, away 65%', $telegram->messages[0]);
-        $this->assertStringContainsString('alice predicted 2-1 (home win): exact score, base 5 + probability bonus 4 = 9', $telegram->messages[0]);
-        $this->assertStringContainsString('bob predicted 1-0 (home win): correct outcome, base 2 + probability bonus 4 = 6', $telegram->messages[0]);
+        $this->assertStringContainsString('Probabilities: home 45%, draw 25%, away 65%', $telegram->messages[0]);
+        $this->assertStringContainsString('alice predicted 2-1 (home win): exact score, base 5 + probability bonus 0 = 5', $telegram->messages[0]);
+        $this->assertStringContainsString('bob predicted 1-0 (home win): correct outcome, base 2 + probability bonus 0 = 2', $telegram->messages[0]);
         $this->assertStringContainsString('charlie predicted 0-1 (away win): wrong outcome, 0 points', $telegram->messages[0]);
         $this->assertStringContainsString('Standings changes:', $telegram->messages[0]);
-        $this->assertStringContainsString('alice: Position: 1 (previous: 2), Points: 16 (gained: 9)', $telegram->messages[0]);
+        $this->assertStringContainsString('alice: Position: 1 (previous: 2), Points: 12 (gained: 5)', $telegram->messages[0]);
     }
 
     private function createScoredFixture()
@@ -108,7 +108,7 @@ class DataUpdateCommandTest extends TestCase
         $match->setAwayTeamId($awayTeam);
         $match->setHomeGoals(2);
         $match->setAwayGoals(1);
-        $match->setHomeWinProbabilityPercent(10);
+        $match->setHomeWinProbabilityPercent(45);
         $match->setDrawProbabilityPercent(25);
         $match->setAwayWinProbabilityPercent(65);
 
@@ -129,9 +129,9 @@ class DataUpdateCommandTest extends TestCase
         $prediction->setAwayGoals(1);
         $prediction->setScoringResult(Prediction::SCORING_RESULT_EXACT);
         $prediction->setBasePoints(5);
-        $prediction->setProbabilityBonus(4);
-        $prediction->setTotalPoints(9);
-        $prediction->setPoints(9);
+        $prediction->setProbabilityBonus(0);
+        $prediction->setTotalPoints(5);
+        $prediction->setPoints(5);
 
         $outcomePrediction = new Prediction();
         $outcomePrediction->setUserId($outcomeUser);
@@ -140,9 +140,9 @@ class DataUpdateCommandTest extends TestCase
         $outcomePrediction->setAwayGoals(0);
         $outcomePrediction->setScoringResult(Prediction::SCORING_RESULT_OUTCOME);
         $outcomePrediction->setBasePoints(2);
-        $outcomePrediction->setProbabilityBonus(4);
-        $outcomePrediction->setTotalPoints(6);
-        $outcomePrediction->setPoints(6);
+        $outcomePrediction->setProbabilityBonus(0);
+        $outcomePrediction->setTotalPoints(2);
+        $outcomePrediction->setPoints(2);
 
         $wrongPrediction = new Prediction();
         $wrongPrediction->setUserId($wrongUser);
@@ -161,7 +161,7 @@ class DataUpdateCommandTest extends TestCase
         $score->setPosOld(2);
         $score->setPosNew(1);
         $score->setPointsOld(7);
-        $score->setPoints(16);
+        $score->setPoints(12);
 
         return array(
             'tournament' => $tournament,

--- a/tests/Unit/PredictionScorerTest.php
+++ b/tests/Unit/PredictionScorerTest.php
@@ -38,8 +38,8 @@ class PredictionScorerTest extends TestCase
             'correct outcome plus low-probability bonus' => array(1, 0, 10, PredictionScorer::RESULT_OUTCOME, 2, 8, 10),
             'wrong outcome scores zero' => array(0, 1, 10, PredictionScorer::RESULT_WRONG, 0, 0, 0),
             'probability at fifty has no bonus' => array(1, 0, 50, PredictionScorer::RESULT_OUTCOME, 2, 0, 2),
-            'probability just below fifty rounds up' => array(1, 0, 49, PredictionScorer::RESULT_OUTCOME, 2, 1, 3),
-            'very low probability bonus is capped at exact points' => array(1, 0, 0, PredictionScorer::RESULT_OUTCOME, 2, 10, 12),
+            'probability just below fifty has no bonus' => array(1, 0, 49, PredictionScorer::RESULT_OUTCOME, 2, 0, 2),
+            'very low probability bonus is capped at exact points' => array(1, 0, 1, PredictionScorer::RESULT_OUTCOME, 2, 10, 12),
         );
     }
 


### PR DESCRIPTION
Updates probability bonus rounding so near-coin-flip underdogs do not receive bonus points, then cleans up the completed TODO item.