### PR TITLE
Make public registration configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@
 # Host port exposed by the httpd service.
 HTTP_PORT=8080
 
+# Set to false to disable public web registration.
+APP_PUBLIC_REGISTRATION_ENABLED=true
+
 # MySQL container/bootstrap settings.
 MYSQL_DATABASE=sportify
 MYSQL_USER=sportify

--- a/TODO.md
+++ b/TODO.md
@@ -2,11 +2,11 @@
 
 ## Current status
 
-One product hardening task is pending.
+No product hardening tasks are pending.
 
 ## Pending
 
-- Disable public registration from the web UI while keeping CLI/admin-created users available.
+- None.
 
 ## Baseline
 
@@ -53,6 +53,7 @@ One product hardening task is pending.
 - Telegram fixture-added, prediction, and result/scoring messages include probability and scoring details.
 - Admin Data Updates handles non-200 Football-Data responses with a flash message instead of a Symfony 500.
 - FIFA World Cup logo import/display on `/matches` is fixed.
+- Public web registration is configurable with `APP_PUBLIC_REGISTRATION_ENABLED` and defaults to enabled.
 
 ## Notes
 

--- a/app/Resources/views/Security/login.html.twig
+++ b/app/Resources/views/Security/login.html.twig
@@ -33,9 +33,11 @@
                             <label for="remember_me">Remember me</label>
                         </div>
                     </form>
-                    <h2>Don't have an account?<br/>
-                        <a href="{{ path('fos_user_registration_register') }}">Sign up here</a>
-                    </h2>
+                    {% if public_registration_enabled %}
+                        <h2>Don't have an account?<br/>
+                            <a href="{{ path('fos_user_registration_register') }}">Sign up here</a>
+                        </h2>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -97,9 +97,11 @@
                             <li {% if app.request.attributes.get('_route') == 'fos_user_security_login'%}class="active"{% endif %}>
                                 <a class="login" href="{{ path('fos_user_security_login') }}">Log in</a>
                             </li>
-                            <li {% if app.request.attributes.get('_route') == 'fos_user_registration_register'%}class="active"{% endif %}>
-                                <a class="signup" href="{{ path('fos_user_registration_register') }}">Sign up</a>
-                            </li>
+                            {% if public_registration_enabled %}
+                                <li {% if app.request.attributes.get('_route') == 'fos_user_registration_register'%}class="active"{% endif %}>
+                                    <a class="signup" href="{{ path('fos_user_registration_register') }}">Sign up</a>
+                                </li>
+                            {% endif %}
                         {% endif %}
                     </ul>
                 </nav>
@@ -171,9 +173,11 @@
                                         <li {% if app.request.attributes.get('_route') == 'fos_user_security_login'%}class="active"{% endif %}>
                                             <a class="login" href="{{ path('fos_user_security_login') }}">Log in</a>
                                         </li>
-                                        <li {% if app.request.attributes.get('_route') == 'fos_user_registration_register'%}class="active"{% endif %}>
-                                            <a class="signup" href="{{ path('fos_user_registration_register') }}">Sign up</a>
-                                        </li>
+                                        {% if public_registration_enabled %}
+                                            <li {% if app.request.attributes.get('_route') == 'fos_user_registration_register'%}class="active"{% endif %}>
+                                                <a class="signup" href="{{ path('fos_user_registration_register') }}">Sign up</a>
+                                            </li>
+                                        {% endif %}
                                     {% endif %}
                                 </ul>
                             </div><!-- /.navbar-collapse -->

--- a/config/packages/twig.yml
+++ b/config/packages/twig.yml
@@ -4,3 +4,5 @@ twig:
     strict_variables: "%kernel.debug%"
     paths:
         "%kernel.project_dir%/app/Resources/views": ~
+    globals:
+        public_registration_enabled: '%app.public_registration_enabled%'

--- a/config/services.yml
+++ b/config/services.yml
@@ -9,6 +9,8 @@ parameters:
     # application parameters
     football_api.name: football_data_org
     football_api.base_uri: https://api.football-data.org/v4
+    env(APP_PUBLIC_REGISTRATION_ENABLED): 'true'
+    app.public_registration_enabled: '%env(bool:APP_PUBLIC_REGISTRATION_ENABLED)%'
     app.registration_confirmation_enabled: true
     app.oauth_access_token_lifetime: 7776000 # 90 days in seconds
     app.scoring.default_outcome_points: 2

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,6 +7,7 @@ services:
     command: ["sportify-prod-init"]
     environment:
       SYMFONY_ENV: prod
+      APP_PUBLIC_REGISTRATION_ENABLED: ${APP_PUBLIC_REGISTRATION_ENABLED:-true}
     depends_on:
       db:
         condition: service_healthy
@@ -21,6 +22,7 @@ services:
       target: php
     environment:
       SYMFONY_ENV: prod
+      APP_PUBLIC_REGISTRATION_ENABLED: ${APP_PUBLIC_REGISTRATION_ENABLED:-true}
     depends_on:
       init:
         condition: service_completed_successfully

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       COMPOSER_MEMORY_LIMIT: -1
       COMPOSER_FUND: 0
       SYMFONY_ENV: dev
+      APP_PUBLIC_REGISTRATION_ENABLED: ${APP_PUBLIC_REGISTRATION_ENABLED:-true}
     volumes:
       - .:/app
     depends_on:

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -34,11 +34,14 @@ Set the exposed HTTP port and MySQL bootstrap credentials:
 
 ```dotenv
 HTTP_PORT=8080
+APP_PUBLIC_REGISTRATION_ENABLED=true
 MYSQL_DATABASE=sportify
 MYSQL_USER=sportify
 MYSQL_PASSWORD=replace-with-a-secret
 MYSQL_ROOT_PASSWORD=replace-with-a-secret
 ```
+
+Set `APP_PUBLIC_REGISTRATION_ENABLED=false` to disable public web registration while keeping command-line user creation available.
 
 Keep `MYSQL_DATABASE`, `MYSQL_USER`, and `MYSQL_PASSWORD` in sync with the matching database values in `app/config/parameters.yml`.
 

--- a/src/Devlabs/SportifyBundle/Controller/RegistrationController.php
+++ b/src/Devlabs/SportifyBundle/Controller/RegistrationController.php
@@ -16,6 +16,8 @@ class RegistrationController extends AbstractController
 {
     public function registerAction(Request $request)
     {
+        $this->denyDisabledPublicRegistration();
+
         $user = new User();
         $form = $this->createForm(RegistrationFormType::class, $user);
         $form->handleRequest($request);
@@ -56,11 +58,15 @@ class RegistrationController extends AbstractController
 
     public function checkEmailAction()
     {
+        $this->denyDisabledPublicRegistration();
+
         return $this->render('Registration/checkEmail.html.twig');
     }
 
     public function confirmAction($token)
     {
+        $this->denyDisabledPublicRegistration();
+
         $user = $this->container->get('doctrine')->getRepository(User::class)->findOneBy(array('confirmationToken' => $token));
 
         if (!$user) {
@@ -76,7 +82,16 @@ class RegistrationController extends AbstractController
 
     public function confirmedAction()
     {
+        $this->denyDisabledPublicRegistration();
+
         return $this->render('Registration/confirmed.html.twig', array('targetUrl' => null));
+    }
+
+    private function denyDisabledPublicRegistration()
+    {
+        if (!$this->getParameter('app.public_registration_enabled')) {
+            throw new NotFoundHttpException('Registration is disabled.');
+        }
     }
 
     private function updateCanonicalFields(User $user)

--- a/tests/Unit/RegistrationControllerTest.php
+++ b/tests/Unit/RegistrationControllerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests\Unit;
+
+use Devlabs\SportifyBundle\Controller\RegistrationController;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ParameterBag\ContainerBag;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class RegistrationControllerTest extends TestCase
+{
+    public function testRegisterActionIsNotFoundWhenPublicRegistrationIsDisabled()
+    {
+        $container = new Container();
+        $container->setParameter('app.public_registration_enabled', false);
+        $container->set('parameter_bag', new ContainerBag($container));
+
+        $controller = new RegistrationController();
+        $controller->setContainer($container);
+
+        $this->expectException(NotFoundHttpException::class);
+
+        $controller->registerAction(new Request());
+    }
+}


### PR DESCRIPTION
Adds a default-enabled flag for public web registration so deployments can disable signup without affecting command-line user creation.