### PR TITLE
Handle blank admin password prompt

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,11 +2,11 @@
 
 ## Current status
 
-One console-command hardening task is pending.
+No pending upgrade tasks are currently listed.
 
 ## Pending
 
-- Fix `sportify:user:create-admin` when the password prompt is submitted blank. It currently passes `null` into `UserPasswordHasher::hashPassword()` and crashes with a Symfony `TypeError`; it should show a clear app-level validation error such as `Password cannot be blank.` instead.
+- None.
 
 ## Baseline
 
@@ -55,6 +55,7 @@ One console-command hardening task is pending.
 - Admin Data Updates handles non-200 Football-Data responses with a flash message instead of a Symfony 500.
 - FIFA World Cup logo import/display on `/matches` is fixed.
 - Public web registration is configurable with `APP_PUBLIC_REGISTRATION_ENABLED` and defaults to enabled.
+- `sportify:user:create-admin` reports `Password cannot be blank.` instead of crashing when its interactive password prompt is submitted blank.
 
 ## Notes
 

--- a/src/Devlabs/SportifyBundle/Command/CreateAdminUserCommand.php
+++ b/src/Devlabs/SportifyBundle/Command/CreateAdminUserCommand.php
@@ -73,8 +73,8 @@ class CreateAdminUserCommand extends Command
             $password = $this->getHelper('question')->ask($input, $output, $question);
         }
 
-        if ($password === '') {
-            $output->writeln('<error>Please provide a password.</error>');
+        if ($password === null || $password === '') {
+            $output->writeln('<error>Password cannot be blank.</error>');
 
             return 1;
         }

--- a/tests/Integration/CreateAdminUserCommandTest.php
+++ b/tests/Integration/CreateAdminUserCommandTest.php
@@ -52,11 +52,23 @@ class CreateAdminUserCommandTest extends DatabaseTestCase
         $this->assertNull($this->em->getRepository(User::class)->findOneBy(array('emailCanonical' => 'second-admin@example.com')));
     }
 
-    private function executeCommand(array $arguments)
+    public function testCommandRefusesBlankInteractivePassword()
+    {
+        $tester = $this->executeCommand(array(
+            'email' => 'admin@example.com',
+        ), array(''));
+
+        $this->assertSame(Command::FAILURE, $tester->getStatusCode());
+        $this->assertStringContainsString('Password cannot be blank.', $tester->getDisplay());
+        $this->assertNull($this->em->getRepository(User::class)->findOneBy(array('emailCanonical' => 'admin@example.com')));
+    }
+
+    private function executeCommand(array $arguments, array $inputs = array())
     {
         $application = new Application(self::$kernel);
         $command = $application->find('sportify:user:create-admin');
         $tester = new CommandTester($command);
+        $tester->setInputs($inputs);
         $tester->execute($arguments);
 
         return $tester;


### PR DESCRIPTION
Fixes blank interactive password handling for sportify:user:create-admin.