### PR TITLE
Mount host localtime in production containers

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,11 +2,11 @@
 
 ## Current status
 
-One production Docker timezone task is pending.
+No pending modernization tasks are currently listed.
 
 ## Pending
 
-- Mount the host `/etc/localtime` into production Docker containers as read-only so container OS time follows the host timezone, e.g. `/etc/localtime:/etc/localtime:ro`.
+- None.
 
 ## Baseline
 
@@ -37,6 +37,7 @@ One production Docker timezone task is pending.
 - Production runtime uses php-fpm + httpd. Node/npm are used only in the asset build stage and are not included in final runtime images.
 - Production app configuration remains host-provided through `app/config/parameters.yml`; infrastructure settings are documented in `.env.example`.
 - Production includes an idempotent `init` service that waits for the database, creates/updates schema, installs bundle assets, and clears/warms prod cache before app startup.
+- Production containers mount the host `/etc/localtime` read-only so container OS time follows the host timezone.
 - First admin creation uses `sportify:user:create-admin`; regular user creation for deployments without SMTP uses `sportify:user:create`; password resets without SMTP use `sportify:user:reset-password`.
 - Deployment documentation covers required local config files, first deployment, upgrades, scheduled commands, and smoke checks.
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,6 +12,7 @@ services:
       db:
         condition: service_healthy
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - bundle-assets:/app/public/bundles
       - prod-cache:/app/var/cache
       - team-logos:/app/public/img/team_logos
@@ -29,6 +30,7 @@ services:
       init:
         condition: service_completed_successfully
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - bundle-assets:/app/public/bundles
       - prod-cache:/app/var/cache
       - team-logos:/app/public/img/team_logos
@@ -48,6 +50,7 @@ services:
     ports:
       - "${HTTP_PORT:-8080}:80"
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - bundle-assets:/app/public/bundles:ro
       - team-logos:/app/public/img/team_logos:ro
       - tournament-logos:/app/public/img/tournament_logos:ro
@@ -59,6 +62,7 @@ services:
     env_file:
       - .env
     volumes:
+      - /etc/localtime:/etc/localtime:ro
       - db-data:/var/lib/mysql
     healthcheck:
       test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -P 3306 -u\"$${MYSQL_USER}\" -p\"$${MYSQL_PASSWORD}\""]


### PR DESCRIPTION
Mounts the host /etc/localtime read-only into production containers.