### PR TITLE
Update knockout and champion scoring rules

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -50,6 +50,7 @@ No pending items.
 - Submitted predictions can be sent to the configured Telegram chat shortly after kickoff with `sportify:telegram:send-predictions`.
 - Data update Telegram notifications use the app-owned Telegram service/config instead of legacy hardcoded send/pin URLs. Sent messages are pinned by default and can be disabled with `telegram.pin_messages: false`.
 - Probability-weighted scoring v1 is implemented with match scoring snapshots, stored prediction scoring breakdowns, exact-prediction percentages based on scored results, and floor-based underdog bonus rounding.
+- Rules page documents World Cup 2026 knockout-stage base scoring recommendations and champion prediction scoring is 15 points.
 - Football-Data integration uses v4, including the v4 teams/fixtures parser fields.
 - Upcoming fixture import uses `football-data.org` plus The Odds API snapshots and skips fixtures when complete odds are unavailable.
 - The prediction page shows probability snapshots, probability bonus chips, and points available for each outcome.

--- a/app/Resources/views/Rules/index.html.twig
+++ b/app/Resources/views/Rules/index.html.twig
@@ -22,7 +22,7 @@
 
                 <h2>Scoring:</h2>
                 <ul>
-                    <li><b>Final champion predicted - 5 points</b></li>
+                    <li><b>Final champion predicted - 15 points</b></li>
                     <li><b>Exact score predicted - 5 points</b></li>
                     <li><b>Correct match outcome predicted - 2 points</b></li>
                 </ul>
@@ -60,9 +60,45 @@
                 </ul>
 
                 <h3>World Cup 2026:</h3>
-                <p>For World Cup 2026, the standard match scoring starts at 2 points for a correct outcome and 5 points for an exact score.</p>
-                <p>In the later stages, these values will be increased. The exact later-stage points will be announced before those matches begin.</p>
-
+                <p>For World Cup 2026, group-stage match scoring is 2 points for a correct outcome and 5 points for an exact score.</p>
+                <p>Group-stage points do not count in the final standings. The group stage is for testing the system and getting familiar with it. Real betting starts from the knockout stage, and scores are reset to zero before the knockout stage begins.</p>
+                <p>Knockout-stage base scoring:</p>
+                <table class="table table-striped">
+                    <thead>
+                        <tr>
+                            <th>Stage</th>
+                            <th class="text-right">Correct outcome</th>
+                            <th class="text-right">Exact score</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>Round of 32</td>
+                            <td class="text-right">3</td>
+                            <td class="text-right">7</td>
+                        </tr>
+                        <tr>
+                            <td>Round of 16</td>
+                            <td class="text-right">4</td>
+                            <td class="text-right">8</td>
+                        </tr>
+                        <tr>
+                            <td>Quarter-final</td>
+                            <td class="text-right">5</td>
+                            <td class="text-right">10</td>
+                        </tr>
+                        <tr>
+                            <td>Semi-final</td>
+                            <td class="text-right">5</td>
+                            <td class="text-right">12</td>
+                        </tr>
+                        <tr>
+                            <td>Final</td>
+                            <td class="text-right">5</td>
+                            <td class="text-right">12</td>
+                        </tr>
+                    </tbody>
+                </table>
                 <h2>HAVE FUN !</h2>
             </div>
         </div>

--- a/src/Devlabs/SportifyBundle/Entity/PredictionChampion.php
+++ b/src/Devlabs/SportifyBundle/Entity/PredictionChampion.php
@@ -5,7 +5,7 @@ namespace Devlabs\SportifyBundle\Entity;
 
 class PredictionChampion
 {
-    const POINTS_WIN = 5;
+    const POINTS_WIN = 15;
 
     private $id;
 

--- a/tests/Functional/ProtectedPageTest.php
+++ b/tests/Functional/ProtectedPageTest.php
@@ -32,6 +32,20 @@ class ProtectedPageTest extends FunctionalTestCase
         $this->assertTrue($this->client->getResponse()->isSuccessful());
     }
 
+    public function testRulesPageShowsKnockoutAndChampionScoring()
+    {
+        $this->createUser('rules_user', 'testpass');
+        $this->login('rules_user@example.com', 'testpass');
+
+        $crawler = $this->client->request('GET', '/rules');
+
+        $this->assertTrue($this->client->getResponse()->isSuccessful());
+        $this->assertStringContainsString('Final champion predicted - 15 points', $crawler->text());
+        $this->assertStringContainsString('Round of 32', $crawler->text());
+        $this->assertStringContainsString('Semi-final', $crawler->text());
+        $this->assertStringContainsString('Final', $crawler->text());
+    }
+
     public function protectedPageProvider()
     {
         return array(

--- a/tests/Integration/RepositoryAndHelperTest.php
+++ b/tests/Integration/RepositoryAndHelperTest.php
@@ -175,13 +175,13 @@ class RepositoryAndHelperTest extends DatabaseTestCase
         $predictionChampionRepository = $this->em->getRepository(PredictionChampion::class);
         $this->assertSame($rightPrediction->getId(), $predictionChampionRepository->getByUserAndTournament($rightUser, $tournament)->getId());
         $this->assertSame(array(), $predictionChampionRepository->getNotScoredByTournament($tournament));
-        $this->assertSame(5, $rightPrediction->getPoints());
+        $this->assertSame(PredictionChampion::POINTS_WIN, $rightPrediction->getPoints());
         $this->assertSame(0, $wrongPrediction->getPoints());
         $this->assertTrue((bool) $rightPrediction->getScoreAdded());
         $this->assertTrue((bool) $wrongPrediction->getScoreAdded());
 
         $scoreRepository = $this->em->getRepository(Score::class);
-        $this->assertSame(5, $scoreRepository->getByUserAndTournament($rightUser, $tournament)->getPoints());
+        $this->assertSame(PredictionChampion::POINTS_WIN, $scoreRepository->getByUserAndTournament($rightUser, $tournament)->getPoints());
         $this->assertSame(0, $scoreRepository->getByUserAndTournament($wrongUser, $tournament)->getPoints());
     }
 

--- a/tests/Unit/EntityBehaviourTest.php
+++ b/tests/Unit/EntityBehaviourTest.php
@@ -272,7 +272,7 @@ class EntityBehaviourTest extends \PHPUnit\Framework\TestCase
         $winningPrediction->setUserId($user);
         $winningPrediction->setTournamentId($tournament);
         $winningPrediction->setTeamId($champion);
-        $winningPrediction->setPoints(5);
+        $winningPrediction->setPoints(PredictionChampion::POINTS_WIN);
         $winningPrediction->setScoreAdded(1);
 
         $losingPrediction = new PredictionChampion();
@@ -281,7 +281,7 @@ class EntityBehaviourTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame(PredictionChampion::POINTS_WIN, $winningPrediction->calculatePoints());
         $this->assertSame(0, $losingPrediction->calculatePoints());
-        $this->assertSame(5, $winningPrediction->getPoints());
+        $this->assertSame(PredictionChampion::POINTS_WIN, $winningPrediction->getPoints());
         $this->assertTrue((bool) $winningPrediction->getScoreAdded());
         $this->assertSame('champion_user', $winningPrediction->getUsername());
         $this->assertSame('champion@example.com', $winningPrediction->getUserEmail());


### PR DESCRIPTION
Updates champion scoring to 15 points and documents World Cup 2026 knockout-stage base scoring on the Rules page.