### PR TITLE
Clarify 90-minute match scoring

### DIFF
--- a/app/Resources/views/Rules/index.html.twig
+++ b/app/Resources/views/Rules/index.html.twig
@@ -29,16 +29,18 @@
 
                 <h3>How match scoring works:</h3>
                 <ul>
-                    <li>If your exact score is correct, you get the exact score points for that match.</li>
-                    <li>If your exact score is wrong but the outcome is correct, you get the outcome points for that match.</li>
-                    <li>If the outcome is wrong, you get 0 points for that match.</li>
+                    <li>The final result for Sportify is the score after 90 minutes plus stoppage time.</li>
+                    <li>Extra time, 120-minute results, penalty shootouts, and who eventually qualifies or lifts the trophy do not change match prediction scoring.</li>
+                    <li>If your exact 90-minute score is correct, you get the exact score points for that match.</li>
+                    <li>If your exact score is wrong but the 90-minute outcome is correct, you get the outcome points for that match.</li>
+                    <li>If the 90-minute outcome is wrong, you get 0 points for that match.</li>
                     <li>The points shown on the match prediction page are the points you can win for that match.</li>
                 </ul>
 
                 <h3>Betting probability bonus:</h3>
                 <ul>
-                    <li>Some matches show betting probability percentages for home win, draw, and away win.</li>
-                    <li>The percentage shows how likely that outcome is considered before the match.</li>
+                    <li>Some matches show betting probability percentages for 90-minute home win, draw, and away win.</li>
+                    <li>The percentage shows how likely that 90-minute outcome is considered before the match.</li>
                     <li>The bonus is calculated from how far below 50% the outcome is. Outcomes at 50% or higher get no bonus.</li>
                     <li>The lower the probability, the bigger the possible bonus. The bonus is rounded down, so a small difference may still add 0 points.</li>
                     <li>The bonus is added to both the correct outcome points and the exact score points for that outcome.</li>
@@ -53,10 +55,10 @@
 
                 <h3>Examples:</h3>
                 <ul>
-                    <li>You predicted 1-0, final score 1-0: exact score.</li>
-                    <li>You predicted 1-0, final score 3-1: correct outcome, home team win.</li>
-                    <li>You predicted 1-2, final score 0-2: correct outcome, away team win.</li>
-                    <li>You predicted 2-2, final score 1-1: correct outcome, draw.</li>
+                    <li>You predicted 1-0, 90-minute final score 1-0: exact score.</li>
+                    <li>You predicted 1-0, 90-minute final score 3-1: correct outcome, home team win.</li>
+                    <li>You predicted 1-2, 90-minute final score 0-2: correct outcome, away team win.</li>
+                    <li>You predicted 2-2, 90-minute final score 1-1: correct outcome, draw.</li>
                 </ul>
 
                 <h3>World Cup 2026:</h3>

--- a/docs/betting-probability-source.md
+++ b/docs/betting-probability-source.md
@@ -4,7 +4,7 @@
 
 Use **The Odds API v4** as the first betting-probability source.
 
-Keep `football-data.org` as the fixture source. For each upcoming fixture that is not already in the database, query The Odds API for that specific match's pre-kickoff head-to-head odds. Add the match and its odds snapshot to the database together. If The Odds API cannot be reached, the match cannot be matched there, or all three home/draw/away outcomes are not returned, do not create the local match. Store enough source text on the match to explain which odds provider/bookmaker/market was used.
+Keep `football-data.org` as the fixture source. For each upcoming fixture that is not already in the database, query The Odds API for that specific match's pre-kickoff head-to-head odds. For soccer, this must be the three-way 90-minute market: home win, draw, or away win after regular time plus stoppage time. Do not use two-way qualification/winner markets, 120-minute outcomes, penalty-shootout outcomes, or tournament outrights. Add the match and its odds snapshot to the database together. If The Odds API cannot be reached, the match cannot be matched there, or all three home/draw/away outcomes are not returned, do not create the local match. Store enough source text on the match to explain which odds provider/bookmaker/market was used.
 
 ## Why this provider
 
@@ -97,7 +97,7 @@ The `/odds` response contains one object per event:
 }
 ```
 
-For soccer, the `h2h` market has three outcomes: home win, draw, and away win. Pick one bookmaker deterministically from an app-owned preference list in code; if none are present, use the first bookmaker returned that has all three `h2h` outcomes. Do not make this another deployment parameter. Store the source as:
+For soccer, the `h2h` market has three outcomes: home win, draw, and away win. This is the market Sportify uses because the presence of a draw represents the 90-minute match result, not a two-way “to qualify” or “winner after extra time/penalties” outcome. Pick one bookmaker deterministically from an app-owned preference list in code; if none are present, use the first bookmaker returned that has all three `h2h` outcomes. Do not make this another deployment parameter. Store the source as:
 
 ```text
 the_odds_api:{sport_key}:{event_id}:{bookmaker_key}:h2h

--- a/src/Devlabs/SportifyBundle/Services/DataUpdates/Parsers/FootballDataOrg.php
+++ b/src/Devlabs/SportifyBundle/Services/DataUpdates/Parsers/FootballDataOrg.php
@@ -61,12 +61,12 @@ class FootballDataOrg
                 $parsedFixture['home_team_goals'] = $this->getTeamScore($fixture->score->fullTime, 'home');
                 $parsedFixture['away_team_goals'] = $this->getTeamScore($fixture->score->fullTime, 'away');
                 $extraTimeHomeGoals = property_exists($fixture->score, 'extraTime') ? $this->getTeamScore($fixture->score->extraTime, 'home') : null;
-                if ($extraTimeHomeGoals != null) {
+                if ($extraTimeHomeGoals !== null) {
                     $parsedFixture['home_team_goals'] = $parsedFixture['home_team_goals'] - $extraTimeHomeGoals;
                     $parsedFixture['away_team_goals'] = $parsedFixture['away_team_goals'] - $this->getTeamScore($fixture->score->extraTime, 'away');
                 }
                 $penaltyHomeGoals = property_exists($fixture->score, 'penalties') ? $this->getTeamScore($fixture->score->penalties, 'home') : null;
-                if ($penaltyHomeGoals != null) {
+                if ($penaltyHomeGoals !== null) {
                     $parsedFixture['home_team_goals'] = $parsedFixture['home_team_goals'] - $penaltyHomeGoals;
                     $parsedFixture['away_team_goals'] = $parsedFixture['away_team_goals'] - $this->getTeamScore($fixture->score->penalties, 'away');
                 }

--- a/tests/Functional/ProtectedPageTest.php
+++ b/tests/Functional/ProtectedPageTest.php
@@ -41,6 +41,8 @@ class ProtectedPageTest extends FunctionalTestCase
 
         $this->assertTrue($this->client->getResponse()->isSuccessful());
         $this->assertStringContainsString('Final champion predicted - 15 points', $crawler->text());
+        $this->assertStringContainsString('The final result for Sportify is the score after 90 minutes plus stoppage time.', $crawler->text());
+        $this->assertStringContainsString('Extra time, 120-minute results, penalty shootouts, and who eventually qualifies or lifts the trophy do not change match prediction scoring.', $crawler->text());
         $this->assertStringContainsString('Round of 32', $crawler->text());
         $this->assertStringContainsString('Semi-final', $crawler->text());
         $this->assertStringContainsString('Final', $crawler->text());

--- a/tests/Unit/FootballDataOrgParserTest.php
+++ b/tests/Unit/FootballDataOrgParserTest.php
@@ -99,6 +99,17 @@ class FootballDataOrgParserTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(3, $parsed[0]['away_team_goals']);
     }
 
+    public function testParseFixturesStoresNinetyMinuteScoreWhenExtraTimeOrPenaltiesContainZeroes()
+    {
+        $finished = $this->createFixture(3, 'FINISHED', '2020-01-03T12:00:00Z', 3, 3, 0, 1, 1, 0);
+
+        $parser = new FootballDataOrg();
+        $parsed = $parser->parseFixtures(array($finished));
+
+        $this->assertSame(2, $parsed[0]['home_team_goals']);
+        $this->assertSame(2, $parsed[0]['away_team_goals']);
+    }
+
     public function testParseFixturesSkipsUnresolvedTeams()
     {
         $valid = $this->createFixture(1, 'SCHEDULED', '2020-01-02T12:00:00Z');

--- a/tests/Unit/TheOddsApiTest.php
+++ b/tests/Unit/TheOddsApiTest.php
@@ -9,6 +9,7 @@ use Devlabs\SportifyBundle\Services\Odds\TheOddsApi;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
@@ -59,7 +60,7 @@ class TheOddsApiTest extends TestCase
         );
     }
 
-    public function testReturnsNullForSuccessfulOddsResponseWithoutCompleteSnapshot()
+    public function testReturnsNullForSuccessfulOddsResponseWithoutCompleteNinetyMinuteSnapshot()
     {
         $api = $this->createApi(array(
             $this->sportsResponse(),
@@ -76,6 +77,33 @@ class TheOddsApiTest extends TestCase
             $this->team('Mexico'),
             $this->team('South Africa')
         ));
+    }
+
+    public function testRequestsSoccerHeadToHeadMarketWithDrawInsteadOfOutrightsOutcome()
+    {
+        $history = array();
+        $api = $this->createApiWithHistory(array(
+            $this->sportsResponse(),
+            $this->eventsResponse(),
+            $this->oddsResponse(array(
+                array('name' => 'Mexico', 'price' => 2.0),
+                array('name' => 'Draw', 'price' => 4.0),
+                array('name' => 'South Africa', 'price' => 4.0),
+            )),
+        ), $history);
+
+        $snapshot = $api->findProbabilitiesForFixture(
+            $this->fixtureData(),
+            $this->tournament(),
+            $this->team('Mexico'),
+            $this->team('South Africa')
+        );
+
+        $this->assertSame('the_odds_api:soccer_fifa_world_cup:event-1:pinnacle:h2h', $snapshot['source']);
+        $oddsRequest = $history[2]['request'];
+        parse_str($oddsRequest->getUri()->getQuery(), $query);
+        $this->assertSame('h2h', $query['markets']);
+        $this->assertNotSame('outrights', $query['markets']);
     }
 
     public function testReturnsNullWhenTokenIsNotConfigured()
@@ -95,6 +123,17 @@ class TheOddsApiTest extends TestCase
         $container = new Container();
         $container->setParameter('odds_api.token', $token);
         $client = new Client(array('handler' => HandlerStack::create(new MockHandler($responses))));
+
+        return new TheOddsApi($container, new OddsProbabilityNormalizer(), 'https://api.example.test', $client);
+    }
+
+    private function createApiWithHistory(array $responses, array &$history)
+    {
+        $container = new Container();
+        $container->setParameter('odds_api.token', 'test-token');
+        $handler = HandlerStack::create(new MockHandler($responses));
+        $handler->push(Middleware::history($history));
+        $client = new Client(array('handler' => $handler));
 
         return new TheOddsApi($container, new OddsProbabilityNormalizer(), 'https://api.example.test', $client);
     }


### PR DESCRIPTION
Clarifies match scoring as 90-minute results and verifies odds snapshots use three-way h2h odds.