### PR TITLE
Fix World Cup rules table contrast

### DIFF
--- a/app/Resources/views/Rules/index.html.twig
+++ b/app/Resources/views/Rules/index.html.twig
@@ -65,7 +65,7 @@
                 <p>For World Cup 2026, group-stage match scoring is 2 points for a correct outcome and 5 points for an exact score.</p>
                 <p>Group-stage points do not count in the final standings. The group stage is for testing the system and getting familiar with it. Real betting starts from the knockout stage, and scores are reset to zero before the knockout stage begins.</p>
                 <p>Knockout-stage base scoring:</p>
-                <table class="table table-striped">
+                <table class="table table-striped rules-scoring-table">
                     <thead>
                         <tr>
                             <th>Stage</th>

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -632,6 +632,9 @@ h2 {
 .page-content-wrapper h2 {
     margin: 50px 0 ;
 }
+.rules-scoring-table.table-striped > tbody > tr:nth-of-type(odd) {
+    color: #333;
+}
 .signup-screen {
     &.content{
         padding-bottom: 10px;


### PR DESCRIPTION
Fix unreadable striped rows in the World Cup 2026 rules scoring table.