### PR TITLE
Notify admins about external API failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Best practice is to use a transactional mail service, like Mailgun, Amazon SES, 
 `odds_api.token` - Configure this with a The Odds API token to import probability snapshots for new upcoming fixtures.
 ` slack.url, slack.channel` - Generate them in [Slack](https://slack.com/apps/A0F7XDUAZ-incoming-webhooks) in order to get notifications.  
 `telegram.bot_token, telegram.chat_id` - Configure these to send scheduled Telegram notifications.
+`telegram.admin_chat_id` - Configure this to send admin-only external API failure alerts.
 `telegram.pin_messages` - Set to `false` to disable pinning Telegram data update notifications. Defaults to `true`.
 `secret` - Symfony variable - generate it by going [here](http://nux.net/secret) or running in shell `openssl rand -hex 20`
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,15 +2,7 @@
 
 ## Current status
 
-Pending task:
-
-- Add centralized external API error notifications to Telegram admin chat:
-  - Add a config parameter such as `telegram.admin_chat_id`.
-  - Reuse/extend the existing Telegram service to send admin-only messages.
-  - Notify from the centralized external API request boundaries, not every caller/function:
-    - `src/Devlabs/SportifyBundle/Services/DataUpdates/Fetchers/FootballDataOrg.php`
-    - `src/Devlabs/SportifyBundle/Services/Odds/TheOddsApi.php`
-  - Cover football-data.org and The Odds API failures without duplicating alerts in higher-level import/update code.
+Pending task: none.
 
 ## Baseline
 
@@ -60,6 +52,7 @@ Pending task:
 - The prediction page shows probability snapshots, probability bonus chips, and points available for each outcome.
 - Telegram fixture-added, prediction, and result/scoring messages include probability and scoring details.
 - Admin Data Updates handles non-200 Football-Data responses with a flash message instead of a Symfony 500.
+- External API failures and unavailable odds snapshots notify the configured Telegram admin chat in prod.
 - FIFA World Cup logo import/display on `/matches` is fixed.
 - Public web registration is configurable with `APP_PUBLIC_REGISTRATION_ENABLED` and defaults to enabled.
 - `sportify:user:create-admin` reports `Password cannot be blank.` instead of crashing when its interactive password prompt is submitted blank.

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -34,6 +34,8 @@ parameters:
     telegram.bot_token: check_the_README_file
     # Telegram chat id for scheduled notifications
     telegram.chat_id: check_the_README_file
+    # Telegram chat id for admin-only alerts
+    telegram.admin_chat_id: check_the_README_file
     # Pin Telegram data update notifications after sending
     telegram.pin_messages: true
 

--- a/docker/symfony/parameters.yml
+++ b/docker/symfony/parameters.yml
@@ -17,6 +17,7 @@ parameters:
     slack.channel: check_the_README_file
     telegram.bot_token: check_the_README_file
     telegram.chat_id: check_the_README_file
+    telegram.admin_chat_id: check_the_README_file
     telegram.pin_messages: true
 
     sportify_api.client_id: ~

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -61,6 +61,7 @@ At minimum, set:
 - `odds_api.token` from The Odds API if upcoming fixture imports should add probability snapshots
 - `slack.url` and `slack.channel` if Slack notifications are used
 - `telegram.bot_token` and `telegram.chat_id` if Telegram notifications are used
+- `telegram.admin_chat_id` if admin-only external API failure alerts are used
 - `sportify_api.client_id` and `sportify_api.client_secret` only if the API token flow is used
 
 `app/config/parameters.yml` is copied into the production image at build time. Rebuild and redeploy the images after changing it.

--- a/src/Devlabs/SportifyBundle/Resources/config/services.yml
+++ b/src/Devlabs/SportifyBundle/Resources/config/services.yml
@@ -73,7 +73,7 @@ services:
 
     app.odds.the_odds_api:
         class: Devlabs\SportifyBundle\Services\Odds\TheOddsApi
-        arguments: ['@service_container', '@app.odds_probability_normalizer', '%odds_api.base_uri%']
+        arguments: ['@service_container', '@app.odds_probability_normalizer', '%odds_api.base_uri%', null, '@app.telegram']
 
     app.scoring_defaults:
         class: Devlabs\SportifyBundle\Services\ScoringDefaults
@@ -123,7 +123,7 @@ services:
 
     app.data_updates.fetchers.football_data_org:
         class: Devlabs\SportifyBundle\Services\DataUpdates\Fetchers\FootballDataOrg
-        arguments: ['@request_stack', '%football_api.base_uri%', '%football_api.token%']
+        arguments: ['@request_stack', '%football_api.base_uri%', '%football_api.token%', '@app.telegram']
 
     app.data_updates.parsers.football_data_org:
         class: Devlabs\SportifyBundle\Services\DataUpdates\Parsers\FootballDataOrg

--- a/src/Devlabs/SportifyBundle/Services/DataUpdates/Fetchers/FootballDataOrg.php
+++ b/src/Devlabs/SportifyBundle/Services/DataUpdates/Fetchers/FootballDataOrg.php
@@ -7,6 +7,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TransferException;
 
 /**
  * Class FootballDataOrg
@@ -20,6 +21,7 @@ class FootballDataOrg
     private $requestStack;
     private $telegram;
     private $lastRequestUrl;
+    private $lastRequestFailureMessage;
 
     public function __construct(RequestStack $requestStack, $baseUri, $apiToken, ?Telegram $telegram = null)
     {
@@ -44,11 +46,17 @@ class FootballDataOrg
         }
 
         $this->lastRequestUrl = $url;
+        $this->lastRequestFailureMessage = null;
 
         try {
             $response = $this->httpClient->get($url, $this->options);
-        } catch (RequestException $e) {
-            $response = $e->getResponse() ?: new Response(500, array(), null, '1.1', 'Request Failed');
+        } catch (TransferException $e) {
+            if ($e instanceof RequestException && $e->getResponse() !== null) {
+                $response = $e->getResponse();
+            } else {
+                $this->lastRequestFailureMessage = $e->getMessage();
+                $response = new Response(500, array(), null, '1.1', 'Request Failed');
+            }
         }
 
         return $response;
@@ -69,6 +77,9 @@ class FootballDataOrg
                 $response->getStatusCode(),
                 $response->getReasonPhrase()
             );
+            if ($this->lastRequestFailureMessage) {
+                $message .= ' Reason: '.$this->lastRequestFailureMessage;
+            }
 
             $this->notifyAdmin($message);
 

--- a/src/Devlabs/SportifyBundle/Services/DataUpdates/Fetchers/FootballDataOrg.php
+++ b/src/Devlabs/SportifyBundle/Services/DataUpdates/Fetchers/FootballDataOrg.php
@@ -2,6 +2,7 @@
 
 namespace Devlabs\SportifyBundle\Services\DataUpdates\Fetchers;
 
+use Devlabs\SportifyBundle\Services\Telegram;
 use Symfony\Component\HttpFoundation\RequestStack;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
@@ -17,14 +18,17 @@ class FootballDataOrg
     private $options;
     private $baseUri;
     private $requestStack;
+    private $telegram;
+    private $lastRequestUrl;
 
-    public function __construct(RequestStack $requestStack, $baseUri, $apiToken)
+    public function __construct(RequestStack $requestStack, $baseUri, $apiToken, ?Telegram $telegram = null)
     {
         $this->requestStack = $requestStack;
         $this->httpClient = new Client();
         $this->options = array();
         $this->options['headers']['X-Auth-Token'] = $apiToken;
         $this->baseUri = $baseUri;
+        $this->telegram = $telegram;
     }
 
     /**
@@ -39,10 +43,12 @@ class FootballDataOrg
             return new Response(400);
         }
 
+        $this->lastRequestUrl = $url;
+
         try {
             $response = $this->httpClient->get($url, $this->options);
         } catch (RequestException $e) {
-            $response = $e->getResponse();
+            $response = $e->getResponse() ?: new Response(500, array(), null, '1.1', 'Request Failed');
         }
 
         return $response;
@@ -64,6 +70,8 @@ class FootballDataOrg
                 $response->getReasonPhrase()
             );
 
+            $this->notifyAdmin($message);
+
             $request = $this->requestStack->getCurrentRequest();
             if ($request && $request->hasSession()) {
                 $request->getSession()->getFlashBag()->add('message', $message);
@@ -77,6 +85,20 @@ class FootballDataOrg
         return ($bodyProperty)
             ? json_decode($response->getBody())->$bodyProperty
             : json_decode($response->getBody());
+    }
+
+    private function notifyAdmin($message)
+    {
+        if ($this->telegram === null) {
+            return;
+        }
+
+        $text = "External API failure: football-data.org\n".$message;
+        if ($this->lastRequestUrl) {
+            $text .= "\nURL: ".$this->lastRequestUrl;
+        }
+
+        $this->telegram->sendAdminMessage($text);
     }
 
     /**

--- a/src/Devlabs/SportifyBundle/Services/DataUpdates/Importer.php
+++ b/src/Devlabs/SportifyBundle/Services/DataUpdates/Importer.php
@@ -110,7 +110,8 @@ class Importer
         $status['fixtures_updated'] = 0;
         $status['added_fixtures'] = array();
 
-        foreach ($fixtures as $fixtureData) {
+        try {
+            foreach ($fixtures as $fixtureData) {
             $apiMatchId = $fixtureData['match_id'];
 
             $matchApiMapping = $this->em->getRepository(ApiMapping::class)
@@ -210,8 +211,11 @@ class Importer
                 $this->em->persist($match);
             }
 
-            // execute queries
-            $this->em->flush();
+                // execute queries
+                $this->em->flush();
+            }
+        } finally {
+            $this->flushOddsUnavailableNotifications();
         }
 
         return $status;
@@ -229,6 +233,15 @@ class Importer
         }
 
         return $this->oddsProvider->findProbabilitiesForFixture($fixtureData, $tournament, $homeTeam, $awayTeam);
+    }
+
+    private function flushOddsUnavailableNotifications()
+    {
+        if ($this->oddsProvider === null || !method_exists($this->oddsProvider, 'flushOddsUnavailableNotifications')) {
+            return;
+        }
+
+        $this->oddsProvider->flushOddsUnavailableNotifications();
     }
 
     private function applyOddsSnapshot(MatchEntity $match, array $oddsSnapshot)

--- a/src/Devlabs/SportifyBundle/Services/DataUpdates/Importer.php
+++ b/src/Devlabs/SportifyBundle/Services/DataUpdates/Importer.php
@@ -133,9 +133,12 @@ class Importer
                     ->findOneById($awayTeamId);
 
                 $datetime = \DateTime::createFromFormat('Y-m-d H:i:s', $fixtureData['match_local_time']);
-                $oddsSnapshot = $this->getOddsSnapshot($fixtureData, $tournament, $homeTeam, $awayTeam);
-                if ($this->needsOddsSnapshot($fixtureData) && $oddsSnapshot === null) {
-                    continue;
+                $oddsSnapshot = null;
+                if ($this->needsOddsSnapshot($fixtureData)) {
+                    $oddsSnapshot = $this->getOddsSnapshot($fixtureData, $tournament, $homeTeam, $awayTeam);
+                    if ($oddsSnapshot === null) {
+                        continue;
+                    }
                 }
 
                 // create new match object by using the parsed data

--- a/src/Devlabs/SportifyBundle/Services/Odds/TheOddsApi.php
+++ b/src/Devlabs/SportifyBundle/Services/Odds/TheOddsApi.php
@@ -4,6 +4,7 @@ namespace Devlabs\SportifyBundle\Services\Odds;
 
 use Devlabs\SportifyBundle\Entity\Team;
 use Devlabs\SportifyBundle\Entity\Tournament;
+use Devlabs\SportifyBundle\Services\Telegram;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -19,6 +20,7 @@ class TheOddsApi
     private $httpClient;
     private $baseUri;
     private $normalizer;
+    private $telegram;
     private $activeSportKeys;
 
     private $sportKeyCandidates = array(
@@ -37,42 +39,62 @@ class TheOddsApi
 
     private $preferredBookmakers = array('pinnacle', 'betfair', 'williamhill', 'bet365');
 
-    public function __construct(ContainerInterface $container, OddsProbabilityNormalizer $normalizer, $baseUri, ?ClientInterface $httpClient = null)
+    public function __construct(ContainerInterface $container, OddsProbabilityNormalizer $normalizer, $baseUri, ?ClientInterface $httpClient = null, ?Telegram $telegram = null)
     {
         $this->container = $container;
         $this->normalizer = $normalizer;
         $this->baseUri = rtrim((string) $baseUri, '/');
         $this->httpClient = $httpClient ?: new Client();
+        $this->telegram = $telegram;
     }
 
     public function findProbabilitiesForFixture(array $fixtureData, Tournament $tournament, Team $homeTeam, Team $awayTeam)
     {
-        $apiToken = $this->getApiToken();
-        if ($apiToken === '') {
-            return null;
-        }
+        try {
+            $apiToken = $this->getApiToken();
+            if ($apiToken === '') {
+                $this->notifyOddsUnavailable($fixtureData, $tournament, $homeTeam, $awayTeam, 'The Odds API token is not configured.');
 
-        $sportKey = $this->getSportKey($tournament, $apiToken);
-        if ($sportKey === null) {
-            return null;
-        }
+                return null;
+            }
 
-        $event = $this->findMatchingEvent($sportKey, $apiToken, $fixtureData, $homeTeam, $awayTeam);
-        if ($event === null || !isset($event->id)) {
-            return null;
-        }
+            $sportKey = $this->getSportKey($tournament, $apiToken);
+            if ($sportKey === null) {
+                $this->notifyOddsUnavailable($fixtureData, $tournament, $homeTeam, $awayTeam, 'No active The Odds API sport key matched the tournament.');
 
-        $oddsEvent = $this->fetchJson('/v4/sports/'.$sportKey.'/events/'.$event->id.'/odds', array(
-            'apiKey' => $apiToken,
-            'regions' => self::REGION,
-            'markets' => self::MARKET,
-            'oddsFormat' => self::ODDS_FORMAT,
-        ));
-        if ($oddsEvent === null) {
-            return null;
-        }
+                return null;
+            }
 
-        return $this->extractSnapshot($oddsEvent, $sportKey, $event->id, $homeTeam, $awayTeam);
+            $event = $this->findMatchingEvent($sportKey, $apiToken, $fixtureData, $homeTeam, $awayTeam);
+            if ($event === null || !isset($event->id)) {
+                $this->notifyOddsUnavailable($fixtureData, $tournament, $homeTeam, $awayTeam, 'No matching The Odds API event was found.');
+
+                return null;
+            }
+
+            $oddsEvent = $this->fetchJson('/v4/sports/'.$sportKey.'/events/'.$event->id.'/odds', array(
+                'apiKey' => $apiToken,
+                'regions' => self::REGION,
+                'markets' => self::MARKET,
+                'oddsFormat' => self::ODDS_FORMAT,
+            ));
+            if ($oddsEvent === null) {
+                $this->notifyOddsUnavailable($fixtureData, $tournament, $homeTeam, $awayTeam, 'The Odds API odds response was empty.');
+
+                return null;
+            }
+
+            $snapshot = $this->extractSnapshot($oddsEvent, $sportKey, $event->id, $homeTeam, $awayTeam);
+            if ($snapshot === null) {
+                $this->notifyOddsUnavailable($fixtureData, $tournament, $homeTeam, $awayTeam, 'No complete home/draw/away odds snapshot was found.');
+            }
+
+            return $snapshot;
+        } catch (\RuntimeException $e) {
+            $this->notifyOddsUnavailable($fixtureData, $tournament, $homeTeam, $awayTeam, $e->getMessage());
+
+            throw $e;
+        }
     }
 
     private function getApiToken()
@@ -240,6 +262,24 @@ class TheOddsApi
         }
 
         return null;
+    }
+
+    private function notifyOddsUnavailable(array $fixtureData, Tournament $tournament, Team $homeTeam, Team $awayTeam, $reason)
+    {
+        if ($this->telegram === null) {
+            return;
+        }
+
+        $matchId = isset($fixtureData['match_id']) ? $fixtureData['match_id'] : 'unknown';
+        $kickoff = isset($fixtureData['match_local_time']) ? $fixtureData['match_local_time'] : 'unknown';
+        $text = "Fixture skipped because odds snapshot is unavailable."
+            ."\nTournament: ".$tournament->getName()
+            ."\nMatch: ".$homeTeam->getName().' vs '.$awayTeam->getName()
+            ."\nKickoff: ".$kickoff
+            ."\nFootball-Data match id: ".$matchId
+            ."\nReason: ".$reason;
+
+        $this->telegram->sendAdminMessage($text);
     }
 
     private function fetchJson($path, array $query)

--- a/src/Devlabs/SportifyBundle/Services/Odds/TheOddsApi.php
+++ b/src/Devlabs/SportifyBundle/Services/Odds/TheOddsApi.php
@@ -15,6 +15,7 @@ class TheOddsApi
     const MARKET = 'h2h';
     const ODDS_FORMAT = 'decimal';
     const MATCH_TOLERANCE_SECONDS = 600;
+    const MAX_ODDS_UNAVAILABLE_ALERT_FIXTURES = 10;
 
     private $container;
     private $httpClient;
@@ -22,6 +23,7 @@ class TheOddsApi
     private $normalizer;
     private $telegram;
     private $activeSportKeys;
+    private $oddsUnavailableNotifications = array();
 
     private $sportKeyCandidates = array(
         'world cup' => array('soccer_fifa_world_cup'),
@@ -264,22 +266,48 @@ class TheOddsApi
         return null;
     }
 
-    private function notifyOddsUnavailable(array $fixtureData, Tournament $tournament, Team $homeTeam, Team $awayTeam, $reason)
+    public function flushOddsUnavailableNotifications()
     {
-        if ($this->telegram === null) {
-            return;
+        if (!$this->oddsUnavailableNotifications) {
+            return null;
         }
 
-        $matchId = isset($fixtureData['match_id']) ? $fixtureData['match_id'] : 'unknown';
-        $kickoff = isset($fixtureData['match_local_time']) ? $fixtureData['match_local_time'] : 'unknown';
-        $text = "Fixture skipped because odds snapshot is unavailable."
-            ."\nTournament: ".$tournament->getName()
-            ."\nMatch: ".$homeTeam->getName().' vs '.$awayTeam->getName()
-            ."\nKickoff: ".$kickoff
-            ."\nFootball-Data match id: ".$matchId
-            ."\nReason: ".$reason;
+        $notifications = $this->oddsUnavailableNotifications;
+        $this->oddsUnavailableNotifications = array();
+        if ($this->telegram === null) {
+            return null;
+        }
 
-        $this->telegram->sendAdminMessage($text);
+        $count = count($notifications);
+        $text = $count === 1
+            ? "Fixture skipped because odds snapshot is unavailable."
+            : $count." fixtures skipped because odds snapshots are unavailable.";
+
+        $shownNotifications = array_slice($notifications, 0, self::MAX_ODDS_UNAVAILABLE_ALERT_FIXTURES);
+        foreach ($shownNotifications as $notification) {
+            $text .= "\n\nTournament: ".$notification['tournament']
+                ."\nMatch: ".$notification['match']
+                ."\nKickoff: ".$notification['kickoff']
+                ."\nFootball-Data match id: ".$notification['match_id']
+                ."\nReason: ".$notification['reason'];
+        }
+
+        if ($count > self::MAX_ODDS_UNAVAILABLE_ALERT_FIXTURES) {
+            $text .= "\n\n...and ".($count - self::MAX_ODDS_UNAVAILABLE_ALERT_FIXTURES)." more.";
+        }
+
+        return $this->telegram->sendAdminMessage($text);
+    }
+
+    private function notifyOddsUnavailable(array $fixtureData, Tournament $tournament, Team $homeTeam, Team $awayTeam, $reason)
+    {
+        $this->oddsUnavailableNotifications[] = array(
+            'tournament' => $tournament->getName(),
+            'match' => $homeTeam->getName().' vs '.$awayTeam->getName(),
+            'kickoff' => isset($fixtureData['match_local_time']) ? $fixtureData['match_local_time'] : 'unknown',
+            'match_id' => isset($fixtureData['match_id']) ? $fixtureData['match_id'] : 'unknown',
+            'reason' => $reason,
+        );
     }
 
     private function fetchJson($path, array $query)

--- a/src/Devlabs/SportifyBundle/Services/Telegram.php
+++ b/src/Devlabs/SportifyBundle/Services/Telegram.php
@@ -42,16 +42,25 @@ class Telegram
     public function sendAdminMessage($text)
     {
         try {
-            return $this->sendToChat($this->getAdminChatId(), $text, null);
+            $response = $this->sendToChat($this->getAdminChatId(), $text, null);
         } catch (\Exception $e) {
-            return new Response(
+            $response = new Response(
                 500,
                 array(),
                 null,
                 '1.1',
                 'Telegram admin notification failed'
             );
+            $this->logAdminNotificationFailure($response, $e);
+
+            return $response;
         }
+
+        if ($response->getStatusCode() < 200 || $response->getStatusCode() >= 300) {
+            $this->logAdminNotificationFailure($response);
+        }
+
+        return $response;
     }
 
     /**
@@ -117,6 +126,20 @@ class Telegram
             && $chatId
             && $this->botToken !== 'check_the_README_file'
             && $chatId !== 'check_the_README_file';
+    }
+
+    private function logAdminNotificationFailure(Response $response, \Exception $exception = null)
+    {
+        $message = sprintf(
+            'Telegram admin notification failed (HTTP %d %s).',
+            $response->getStatusCode(),
+            $response->getReasonPhrase()
+        );
+        if ($exception !== null) {
+            $message .= ' '.$exception->getMessage();
+        }
+
+        error_log($message);
     }
 
     private function getAdminChatId()

--- a/src/Devlabs/SportifyBundle/Services/Telegram.php
+++ b/src/Devlabs/SportifyBundle/Services/Telegram.php
@@ -41,7 +41,17 @@ class Telegram
      */
     public function sendAdminMessage($text)
     {
-        return $this->sendToChat($this->getAdminChatId(), $text);
+        try {
+            return $this->sendToChat($this->getAdminChatId(), $text, null);
+        } catch (\Exception $e) {
+            return new Response(
+                500,
+                array(),
+                null,
+                '1.1',
+                'Telegram admin notification failed'
+            );
+        }
     }
 
     /**
@@ -70,21 +80,25 @@ class Telegram
         }
     }
 
-    private function sendToChat($chatId, $text)
+    private function sendToChat($chatId, $text, $parseMode = 'Markdown')
     {
         if (!$this->isEnabled($chatId)) {
             return $this->disabledResponse();
+        }
+
+        $formParams = array(
+            'chat_id' => $chatId,
+            'text' => $text,
+        );
+        if ($parseMode !== null) {
+            $formParams['parse_mode'] = $parseMode;
         }
 
         try {
             return $this->httpClient->post(
                 'https://api.telegram.org/bot'.$this->botToken.'/sendMessage',
                 array(
-                    'form_params' => array(
-                        'chat_id' => $chatId,
-                        'text' => $text,
-                        'parse_mode' => 'Markdown',
-                    ),
+                    'form_params' => $formParams,
                     'allow_redirects' => false,
                     'timeout' => 5,
                 )

--- a/src/Devlabs/SportifyBundle/Services/Telegram.php
+++ b/src/Devlabs/SportifyBundle/Services/Telegram.php
@@ -33,26 +33,15 @@ class Telegram
      */
     public function sendMessage($text)
     {
-        if (!$this->isEnabled()) {
-            return $this->disabledResponse();
-        }
+        return $this->sendToChat($this->chatId, $text);
+    }
 
-        try {
-            return $this->httpClient->post(
-                'https://api.telegram.org/bot'.$this->botToken.'/sendMessage',
-                array(
-                    'form_params' => array(
-                        'chat_id' => $this->chatId,
-                        'text' => $text,
-                        'parse_mode' => 'Markdown',
-                    ),
-                    'allow_redirects' => false,
-                    'timeout' => 5,
-                )
-            );
-        } catch (RequestException $e) {
-            return $e->getResponse() ?: new Response(500);
-        }
+    /**
+     * Send a Telegram message to the admin chat.
+     */
+    public function sendAdminMessage($text)
+    {
+        return $this->sendToChat($this->getAdminChatId(), $text);
     }
 
     /**
@@ -60,7 +49,7 @@ class Telegram
      */
     public function pinMessage($messageId)
     {
-        if (!$this->isEnabled()) {
+        if (!$this->isEnabled($this->chatId)) {
             return $this->disabledResponse();
         }
 
@@ -81,15 +70,48 @@ class Telegram
         }
     }
 
-    private function isEnabled()
+    private function sendToChat($chatId, $text)
+    {
+        if (!$this->isEnabled($chatId)) {
+            return $this->disabledResponse();
+        }
+
+        try {
+            return $this->httpClient->post(
+                'https://api.telegram.org/bot'.$this->botToken.'/sendMessage',
+                array(
+                    'form_params' => array(
+                        'chat_id' => $chatId,
+                        'text' => $text,
+                        'parse_mode' => 'Markdown',
+                    ),
+                    'allow_redirects' => false,
+                    'timeout' => 5,
+                )
+            );
+        } catch (RequestException $e) {
+            return $e->getResponse() ?: new Response(500);
+        }
+    }
+
+    private function isEnabled($chatId)
     {
         $env = $this->container->get('kernel')->getEnvironment();
 
         return $env === 'prod'
             && $this->botToken
-            && $this->chatId
+            && $chatId
             && $this->botToken !== 'check_the_README_file'
-            && $this->chatId !== 'check_the_README_file';
+            && $chatId !== 'check_the_README_file';
+    }
+
+    private function getAdminChatId()
+    {
+        if (!$this->container->hasParameter('telegram.admin_chat_id')) {
+            return null;
+        }
+
+        return $this->container->getParameter('telegram.admin_chat_id');
     }
 
     private function disabledResponse()

--- a/src/Devlabs/SportifyBundle/Services/Telegram.php
+++ b/src/Devlabs/SportifyBundle/Services/Telegram.php
@@ -136,7 +136,7 @@ class Telegram
             $response->getReasonPhrase()
         );
         if ($exception !== null) {
-            $message .= ' '.$exception->getMessage();
+            $message .= ' Exception: '.get_class($exception);
         }
 
         error_log($message);

--- a/src/Devlabs/SportifyBundle/Services/Telegram.php
+++ b/src/Devlabs/SportifyBundle/Services/Telegram.php
@@ -41,8 +41,13 @@ class Telegram
      */
     public function sendAdminMessage($text)
     {
+        $adminChatId = $this->getAdminChatId();
+        if (!$this->isEnabled($adminChatId)) {
+            return $this->disabledResponse();
+        }
+
         try {
-            $response = $this->sendToChat($this->getAdminChatId(), $text, null);
+            $response = $this->sendToChat($adminChatId, $text, null);
         } catch (\Exception $e) {
             $response = new Response(
                 500,
@@ -128,7 +133,7 @@ class Telegram
             && $chatId !== 'check_the_README_file';
     }
 
-    private function logAdminNotificationFailure(Response $response, \Exception $exception = null)
+    private function logAdminNotificationFailure(Response $response, ?\Exception $exception = null)
     {
         $message = sprintf(
             'Telegram admin notification failed (HTTP %d %s).',

--- a/tests/Integration/OddsFixtureImportTest.php
+++ b/tests/Integration/OddsFixtureImportTest.php
@@ -62,10 +62,12 @@ class OddsFixtureImportTest extends DatabaseTestCase
         $this->createApiMapping($homeTeam, 'Team', 'football_data_org', 10);
         $this->createApiMapping($awayTeam, 'Team', 'football_data_org', 20);
 
-        $importer = $this->createImporter(new FakeFixtureOddsProvider(array()));
+        $oddsProvider = new FakeFixtureOddsProvider(array());
+        $importer = $this->createImporter($oddsProvider);
 
         $status = $importer->importFixtures(array($this->scheduledFixture(501)), $tournament, 'football_data_org');
 
+        $this->assertSame(1, $oddsProvider->flushCount);
         $this->assertSame(0, $status['fixtures_added']);
         $this->assertSame(array(), $status['added_fixtures']);
         $this->assertNull($this->em->getRepository(ApiMapping::class)
@@ -117,6 +119,7 @@ class OddsFixtureImportTest extends DatabaseTestCase
 
 class FakeFixtureOddsProvider
 {
+    public $flushCount = 0;
     private $snapshots;
 
     public function __construct(array $snapshots)
@@ -131,5 +134,10 @@ class FakeFixtureOddsProvider
         }
 
         return $this->snapshots[$fixtureData['match_id']];
+    }
+
+    public function flushOddsUnavailableNotifications()
+    {
+        $this->flushCount++;
     }
 }

--- a/tests/Unit/FootballDataOrgFetcherTest.php
+++ b/tests/Unit/FootballDataOrgFetcherTest.php
@@ -4,6 +4,8 @@ namespace Tests\Unit;
 
 use Devlabs\SportifyBundle\Services\DataUpdates\Fetchers\FootballDataOrg;
 use Devlabs\SportifyBundle\Services\Telegram;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Psr7\Request as GuzzleRequest;
 use GuzzleHttp\Psr7\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -54,6 +56,27 @@ class FootballDataOrgFetcherTest extends \PHPUnit\Framework\TestCase
         $this->assertStringContainsString('External API failure: football-data.org', $telegram->adminMessages[0]);
         $this->assertStringContainsString('Football-Data request failed (HTTP 429 Too Many Requests).', $telegram->adminMessages[0]);
     }
+
+    public function testConnectionFailureSendsAdminAlertAndThrows()
+    {
+        $telegram = new FakeFootballDataOrgAdminTelegram();
+        $fetcher = new FootballDataOrg(new RequestStack(), 'https://api.football-data.org/v4', 'test-token', $telegram);
+        $property = new \ReflectionProperty(FootballDataOrg::class, 'httpClient');
+        $property->setAccessible(true);
+        $property->setValue($fetcher, new FailingFootballDataOrgHttpClient());
+
+        try {
+            $fetcher->processResponse($fetcher->getResponse('https://api.football-data.org/v4/competitions'));
+            $this->fail('Expected Football-Data connection failure to throw.');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('Football-Data request failed (HTTP 500 Request Failed). Reason: Connection failed', $e->getMessage());
+        }
+
+        $this->assertCount(1, $telegram->adminMessages);
+        $this->assertStringContainsString('External API failure: football-data.org', $telegram->adminMessages[0]);
+        $this->assertStringContainsString('Reason: Connection failed', $telegram->adminMessages[0]);
+        $this->assertStringContainsString('URL: https://api.football-data.org/v4/competitions', $telegram->adminMessages[0]);
+    }
 }
 
 class FakeFootballDataOrgAdminTelegram extends Telegram
@@ -69,5 +92,13 @@ class FakeFootballDataOrgAdminTelegram extends Telegram
         $this->adminMessages[] = $text;
 
         return new Response(200);
+    }
+}
+
+class FailingFootballDataOrgHttpClient
+{
+    public function get($url, array $options)
+    {
+        throw new ConnectException('Connection failed', new GuzzleRequest('GET', $url));
     }
 }

--- a/tests/Unit/FootballDataOrgFetcherTest.php
+++ b/tests/Unit/FootballDataOrgFetcherTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit;
 
 use Devlabs\SportifyBundle\Services\DataUpdates\Fetchers\FootballDataOrg;
+use Devlabs\SportifyBundle\Services\Telegram;
 use GuzzleHttp\Psr7\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -35,5 +36,38 @@ class FootballDataOrgFetcherTest extends \PHPUnit\Framework\TestCase
         $this->expectExceptionMessage('Football-Data request failed (HTTP 429 Too Many Requests).');
 
         $fetcher->processResponse(new Response(429), 'teams');
+    }
+
+    public function testProcessResponseSendsAdminAlertForNonOkResponse()
+    {
+        $telegram = new FakeFootballDataOrgAdminTelegram();
+        $fetcher = new FootballDataOrg(new RequestStack(), 'https://api.football-data.org/v4', 'test-token', $telegram);
+
+        try {
+            $fetcher->processResponse(new Response(429), 'teams');
+            $this->fail('Expected Football-Data response processing to throw.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Football-Data request failed (HTTP 429 Too Many Requests).', $e->getMessage());
+        }
+
+        $this->assertCount(1, $telegram->adminMessages);
+        $this->assertStringContainsString('External API failure: football-data.org', $telegram->adminMessages[0]);
+        $this->assertStringContainsString('Football-Data request failed (HTTP 429 Too Many Requests).', $telegram->adminMessages[0]);
+    }
+}
+
+class FakeFootballDataOrgAdminTelegram extends Telegram
+{
+    public $adminMessages = array();
+
+    public function __construct()
+    {
+    }
+
+    public function sendAdminMessage($text)
+    {
+        $this->adminMessages[] = $text;
+
+        return new Response(200);
     }
 }

--- a/tests/Unit/TelegramTest.php
+++ b/tests/Unit/TelegramTest.php
@@ -33,7 +33,9 @@ class TelegramTest extends TestCase
 
         $this->assertSame(500, $response->getStatusCode());
         $this->assertSame('Telegram admin notification failed', $response->getReasonPhrase());
-        $this->assertStringContainsString('Telegram admin notification failed (HTTP 500 Telegram admin notification failed). Connection failed', $log);
+        $this->assertStringContainsString('Telegram admin notification failed (HTTP 500 Telegram admin notification failed). Exception: GuzzleHttp\\Exception\\ConnectException', $log);
+        $this->assertStringNotContainsString('bot-token', $log);
+        $this->assertStringNotContainsString('/botbot-token/sendMessage', $log);
     }
 
     public function testSendAdminMessageLogsNonSuccessResponse()

--- a/tests/Unit/TelegramTest.php
+++ b/tests/Unit/TelegramTest.php
@@ -27,10 +27,43 @@ class TelegramTest extends TestCase
     {
         $telegram = $this->createTelegram(new FailingTelegramHttpClient());
 
-        $response = $telegram->sendAdminMessage('External API failure');
+        list($response, $log) = $this->captureErrorLog(function () use ($telegram) {
+            return $telegram->sendAdminMessage('External API failure');
+        });
 
         $this->assertSame(500, $response->getStatusCode());
         $this->assertSame('Telegram admin notification failed', $response->getReasonPhrase());
+        $this->assertStringContainsString('Telegram admin notification failed (HTTP 500 Telegram admin notification failed). Connection failed', $log);
+    }
+
+    public function testSendAdminMessageLogsNonSuccessResponse()
+    {
+        $telegram = $this->createTelegram(new UnsuccessfulTelegramHttpClient());
+
+        list($response, $log) = $this->captureErrorLog(function () use ($telegram) {
+            return $telegram->sendAdminMessage('External API failure');
+        });
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertStringContainsString('Telegram admin notification failed (HTTP 400 Bad Request).', $log);
+    }
+
+    private function captureErrorLog(callable $callback)
+    {
+        $logFile = tempnam(sys_get_temp_dir(), 'telegram-error-log-');
+        $previousLog = ini_set('error_log', $logFile);
+
+        try {
+            $result = $callback();
+            $log = file_exists($logFile) ? file_get_contents($logFile) : '';
+        } finally {
+            ini_set('error_log', $previousLog);
+            if (file_exists($logFile)) {
+                unlink($logFile);
+            }
+        }
+
+        return array($result, $log);
     }
 
     private function createTelegram($client)
@@ -73,5 +106,13 @@ class FailingTelegramHttpClient
     public function post($url, array $options)
     {
         throw new ConnectException('Connection failed', new Request('POST', $url));
+    }
+}
+
+class UnsuccessfulTelegramHttpClient
+{
+    public function post($url, array $options)
+    {
+        return new Response(400, array(), null, '1.1', 'Bad Request');
     }
 }

--- a/tests/Unit/TelegramTest.php
+++ b/tests/Unit/TelegramTest.php
@@ -50,6 +50,18 @@ class TelegramTest extends TestCase
         $this->assertStringContainsString('Telegram admin notification failed (HTTP 400 Bad Request).', $log);
     }
 
+    public function testSendAdminMessageDoesNotLogWhenAdminChatIsDisabled()
+    {
+        $telegram = $this->createTelegram(new FailingTelegramHttpClient(), 'check_the_README_file');
+
+        list($response, $log) = $this->captureErrorLog(function () use ($telegram) {
+            return $telegram->sendAdminMessage('External API failure');
+        });
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame('', $log);
+    }
+
     private function captureErrorLog(callable $callback)
     {
         $logFile = tempnam(sys_get_temp_dir(), 'telegram-error-log-');
@@ -68,11 +80,11 @@ class TelegramTest extends TestCase
         return array($result, $log);
     }
 
-    private function createTelegram($client)
+    private function createTelegram($client, $adminChatId = 'admin-chat')
     {
         $container = new Container();
         $container->set('kernel', new FakeTelegramKernel());
-        $container->setParameter('telegram.admin_chat_id', 'admin-chat');
+        $container->setParameter('telegram.admin_chat_id', $adminChatId);
 
         $telegram = new Telegram($container, 'bot-token', 'main-chat');
         $property = new \ReflectionProperty(Telegram::class, 'httpClient');

--- a/tests/Unit/TelegramTest.php
+++ b/tests/Unit/TelegramTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Unit;
+
+use Devlabs\SportifyBundle\Services\Telegram;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+
+class TelegramTest extends TestCase
+{
+    public function testSendAdminMessageDoesNotUseMarkdownParseMode()
+    {
+        $telegram = $this->createTelegram($client = new FakeTelegramHttpClient());
+
+        $response = $telegram->sendAdminMessage('soccer_fifa_world_cup [Mexico]');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('admin-chat', $client->options['form_params']['chat_id']);
+        $this->assertSame('soccer_fifa_world_cup [Mexico]', $client->options['form_params']['text']);
+        $this->assertArrayNotHasKey('parse_mode', $client->options['form_params']);
+    }
+
+    public function testSendAdminMessageDoesNotThrowWhenTelegramTransportFails()
+    {
+        $telegram = $this->createTelegram(new FailingTelegramHttpClient());
+
+        $response = $telegram->sendAdminMessage('External API failure');
+
+        $this->assertSame(500, $response->getStatusCode());
+        $this->assertSame('Telegram admin notification failed', $response->getReasonPhrase());
+    }
+
+    private function createTelegram($client)
+    {
+        $container = new Container();
+        $container->set('kernel', new FakeTelegramKernel());
+        $container->setParameter('telegram.admin_chat_id', 'admin-chat');
+
+        $telegram = new Telegram($container, 'bot-token', 'main-chat');
+        $property = new \ReflectionProperty(Telegram::class, 'httpClient');
+        $property->setAccessible(true);
+        $property->setValue($telegram, $client);
+
+        return $telegram;
+    }
+}
+
+class FakeTelegramKernel
+{
+    public function getEnvironment()
+    {
+        return 'prod';
+    }
+}
+
+class FakeTelegramHttpClient
+{
+    public $options;
+
+    public function post($url, array $options)
+    {
+        $this->options = $options;
+
+        return new Response(200);
+    }
+}
+
+class FailingTelegramHttpClient
+{
+    public function post($url, array $options)
+    {
+        throw new ConnectException('Connection failed', new Request('POST', $url));
+    }
+}

--- a/tests/Unit/TheOddsApiTest.php
+++ b/tests/Unit/TheOddsApiTest.php
@@ -63,6 +63,9 @@ class TheOddsApiTest extends TestCase
             $this->assertStringContainsString('The Odds API request failed for "/v4/sports/soccer_fifa_world_cup/events/event-1/odds" (HTTP 429', $e->getMessage());
         }
 
+        $this->assertCount(0, $telegram->adminMessages);
+        $api->flushOddsUnavailableNotifications();
+
         $this->assertCount(1, $telegram->adminMessages);
         $this->assertStringContainsString('Fixture skipped because odds snapshot is unavailable.', $telegram->adminMessages[0]);
         $this->assertStringContainsString('Match: Mexico vs South Africa', $telegram->adminMessages[0]);
@@ -87,10 +90,43 @@ class TheOddsApiTest extends TestCase
             $this->team('Mexico'),
             $this->team('South Africa')
         ));
+        $this->assertCount(0, $telegram->adminMessages);
+
+        $api->flushOddsUnavailableNotifications();
+
         $this->assertCount(1, $telegram->adminMessages);
         $this->assertStringContainsString('Fixture skipped because odds snapshot is unavailable.', $telegram->adminMessages[0]);
         $this->assertStringContainsString('Football-Data match id: 500', $telegram->adminMessages[0]);
         $this->assertStringContainsString('Reason: No complete home/draw/away odds snapshot was found.', $telegram->adminMessages[0]);
+    }
+
+    public function testBatchesUnavailableOddsNotificationsUntilFlush()
+    {
+        $telegram = new FakeTheOddsApiAdminTelegram();
+        $api = $this->createApi(array(), 'check_the_README_file', $telegram);
+
+        $this->assertNull($api->findProbabilitiesForFixture(
+            $this->fixtureData(500),
+            $this->tournament(),
+            $this->team('Mexico'),
+            $this->team('South Africa')
+        ));
+        $this->assertNull($api->findProbabilitiesForFixture(
+            $this->fixtureData(501),
+            $this->tournament(),
+            $this->team('Canada'),
+            $this->team('Morocco')
+        ));
+        $this->assertCount(0, $telegram->adminMessages);
+
+        $api->flushOddsUnavailableNotifications();
+
+        $this->assertCount(1, $telegram->adminMessages);
+        $this->assertStringContainsString('2 fixtures skipped because odds snapshots are unavailable.', $telegram->adminMessages[0]);
+        $this->assertStringContainsString('Match: Mexico vs South Africa', $telegram->adminMessages[0]);
+        $this->assertStringContainsString('Football-Data match id: 500', $telegram->adminMessages[0]);
+        $this->assertStringContainsString('Match: Canada vs Morocco', $telegram->adminMessages[0]);
+        $this->assertStringContainsString('Football-Data match id: 501', $telegram->adminMessages[0]);
     }
 
     public function testRequestsSoccerHeadToHeadMarketWithDrawInsteadOfOutrightsOutcome()
@@ -189,10 +225,10 @@ class TheOddsApiTest extends TestCase
         )));
     }
 
-    private function fixtureData()
+    private function fixtureData($matchId = 500)
     {
         return array(
-            'match_id' => 500,
+            'match_id' => $matchId,
             'match_local_time' => '2026-06-11 19:00:00',
         );
     }

--- a/tests/Unit/TheOddsApiTest.php
+++ b/tests/Unit/TheOddsApiTest.php
@@ -6,6 +6,7 @@ use Devlabs\SportifyBundle\Entity\Team;
 use Devlabs\SportifyBundle\Entity\Tournament;
 use Devlabs\SportifyBundle\Services\Odds\OddsProbabilityNormalizer;
 use Devlabs\SportifyBundle\Services\Odds\TheOddsApi;
+use Devlabs\SportifyBundle\Services\Telegram;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
@@ -43,25 +44,34 @@ class TheOddsApiTest extends TestCase
 
     public function testThrowsWhenOddsEndpointFails()
     {
+        $telegram = new FakeTheOddsApiAdminTelegram();
         $api = $this->createApi(array(
             $this->sportsResponse(),
             $this->eventsResponse(),
             new Response(429),
-        ));
+        ), 'test-token', $telegram);
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('The Odds API request failed for "/v4/sports/soccer_fifa_world_cup/events/event-1/odds" (HTTP 429');
+        try {
+            $api->findProbabilitiesForFixture(
+                $this->fixtureData(),
+                $this->tournament(),
+                $this->team('Mexico'),
+                $this->team('South Africa')
+            );
+            $this->fail('Expected The Odds API failure to throw.');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('The Odds API request failed for "/v4/sports/soccer_fifa_world_cup/events/event-1/odds" (HTTP 429', $e->getMessage());
+        }
 
-        $api->findProbabilitiesForFixture(
-            $this->fixtureData(),
-            $this->tournament(),
-            $this->team('Mexico'),
-            $this->team('South Africa')
-        );
+        $this->assertCount(1, $telegram->adminMessages);
+        $this->assertStringContainsString('Fixture skipped because odds snapshot is unavailable.', $telegram->adminMessages[0]);
+        $this->assertStringContainsString('Match: Mexico vs South Africa', $telegram->adminMessages[0]);
+        $this->assertStringContainsString('Reason: The Odds API request failed for "/v4/sports/soccer_fifa_world_cup/events/event-1/odds" (HTTP 429', $telegram->adminMessages[0]);
     }
 
     public function testReturnsNullForSuccessfulOddsResponseWithoutCompleteNinetyMinuteSnapshot()
     {
+        $telegram = new FakeTheOddsApiAdminTelegram();
         $api = $this->createApi(array(
             $this->sportsResponse(),
             $this->eventsResponse(),
@@ -69,7 +79,7 @@ class TheOddsApiTest extends TestCase
                 array('name' => 'Mexico', 'price' => 2.0),
                 array('name' => 'South Africa', 'price' => 4.0),
             )),
-        ));
+        ), 'test-token', $telegram);
 
         $this->assertNull($api->findProbabilitiesForFixture(
             $this->fixtureData(),
@@ -77,6 +87,10 @@ class TheOddsApiTest extends TestCase
             $this->team('Mexico'),
             $this->team('South Africa')
         ));
+        $this->assertCount(1, $telegram->adminMessages);
+        $this->assertStringContainsString('Fixture skipped because odds snapshot is unavailable.', $telegram->adminMessages[0]);
+        $this->assertStringContainsString('Football-Data match id: 500', $telegram->adminMessages[0]);
+        $this->assertStringContainsString('Reason: No complete home/draw/away odds snapshot was found.', $telegram->adminMessages[0]);
     }
 
     public function testRequestsSoccerHeadToHeadMarketWithDrawInsteadOfOutrightsOutcome()
@@ -118,13 +132,13 @@ class TheOddsApiTest extends TestCase
         ));
     }
 
-    private function createApi(array $responses, $token = 'test-token')
+    private function createApi(array $responses, $token = 'test-token', ?Telegram $telegram = null)
     {
         $container = new Container();
         $container->setParameter('odds_api.token', $token);
         $client = new Client(array('handler' => HandlerStack::create(new MockHandler($responses))));
 
-        return new TheOddsApi($container, new OddsProbabilityNormalizer(), 'https://api.example.test', $client);
+        return new TheOddsApi($container, new OddsProbabilityNormalizer(), 'https://api.example.test', $client, $telegram);
     }
 
     private function createApiWithHistory(array $responses, array &$history)
@@ -178,6 +192,7 @@ class TheOddsApiTest extends TestCase
     private function fixtureData()
     {
         return array(
+            'match_id' => 500,
             'match_local_time' => '2026-06-11 19:00:00',
         );
     }
@@ -196,5 +211,21 @@ class TheOddsApiTest extends TestCase
         $team->setName($name);
 
         return $team;
+    }
+}
+
+class FakeTheOddsApiAdminTelegram extends Telegram
+{
+    public $adminMessages = array();
+
+    public function __construct()
+    {
+    }
+
+    public function sendAdminMessage($text)
+    {
+        $this->adminMessages[] = $text;
+
+        return new Response(200);
     }
 }


### PR DESCRIPTION
Adds Telegram admin alerts for Football-Data failures and unavailable Odds API snapshots.