### PR TITLE
Improve Odds API team matching

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,11 +2,11 @@
 
 ## Current status
 
-Pending task: improve cross-provider team matching for fixture odds imports.
+Pending task: none currently tracked.
 
 ## Pending
 
-- Design and implement canonical team/provider mapping for Odds API fixture matching. Keep Football-Data teams as canonical app teams, store reusable Odds API team-name mappings per tournament/provider, auto-learn safe mappings from Football-Data metadata (`name`, `shortName`, `tla`, `area.name`, `area.code`) plus kickoff/home-away constraints, and notify the admin when a mapping is missing or ambiguous instead of relying on hardcoded aliases.
+- None.
 
 ## Baseline
 
@@ -61,6 +61,7 @@ Pending task: improve cross-provider team matching for fixture odds imports.
 - Public web registration is configurable with `APP_PUBLIC_REGISTRATION_ENABLED` and defaults to enabled.
 - `sportify:user:create-admin` reports `Password cannot be blank.` instead of crashing when its interactive password prompt is submitted blank.
 - Shared filter forms handle submitted `filter[...]` arrays without Symfony 7 `InputBag::get()` scalar access errors.
+- Fixture odds imports keep Football-Data teams canonical, auto-learn reusable The Odds API team-name mappings per tournament/provider from safe Football-Data metadata plus kickoff/home-away constraints, and notify the admin when provider team mappings are missing or ambiguous.
 
 ## Notes
 

--- a/config/doctrine/OddsProviderTeamMapping.orm.xml
+++ b/config/doctrine/OddsProviderTeamMapping.orm.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+  <entity repository-class="Devlabs\SportifyBundle\Entity\OddsProviderTeamMappingRepository" name="Devlabs\SportifyBundle\Entity\OddsProviderTeamMapping" table="odds_provider_team_mappings">
+    <unique-constraints>
+      <unique-constraint name="tournament_provider_team_name" columns="tournament_id,provider,normalized_provider_team_name"/>
+    </unique-constraints>
+    <id name="id" type="integer" column="id">
+      <generator strategy="IDENTITY"/>
+    </id>
+    <field name="tournamentId" type="integer" column="tournament_id" nullable="false"/>
+    <field name="provider" type="string" column="provider" length="50" nullable="false"/>
+    <field name="providerTeamName" type="string" column="provider_team_name" length="100" nullable="false"/>
+    <field name="normalizedProviderTeamName" type="string" column="normalized_provider_team_name" length="100" nullable="false"/>
+    <field name="teamId" type="integer" column="team_id" nullable="false"/>
+  </entity>
+</doctrine-mapping>

--- a/src/Devlabs/SportifyBundle/Entity/OddsProviderTeamMapping.php
+++ b/src/Devlabs/SportifyBundle/Entity/OddsProviderTeamMapping.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Devlabs\SportifyBundle\Entity;
+
+class OddsProviderTeamMapping
+{
+    private $id;
+
+    private $tournamentId;
+
+    private $provider;
+
+    private $providerTeamName;
+
+    private $normalizedProviderTeamName;
+
+    private $teamId;
+
+    /**
+     * Get id
+     *
+     * @return integer
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Set tournamentId
+     *
+     * @param integer $tournamentId
+     *
+     * @return OddsProviderTeamMapping
+     */
+    public function setTournamentId($tournamentId)
+    {
+        $this->tournamentId = $tournamentId;
+
+        return $this;
+    }
+
+    /**
+     * Get tournamentId
+     *
+     * @return integer
+     */
+    public function getTournamentId()
+    {
+        return $this->tournamentId;
+    }
+
+    /**
+     * Set provider
+     *
+     * @param string $provider
+     *
+     * @return OddsProviderTeamMapping
+     */
+    public function setProvider($provider)
+    {
+        $this->provider = $provider;
+
+        return $this;
+    }
+
+    /**
+     * Get provider
+     *
+     * @return string
+     */
+    public function getProvider()
+    {
+        return $this->provider;
+    }
+
+    /**
+     * Set providerTeamName
+     *
+     * @param string $providerTeamName
+     *
+     * @return OddsProviderTeamMapping
+     */
+    public function setProviderTeamName($providerTeamName)
+    {
+        $this->providerTeamName = $providerTeamName;
+
+        return $this;
+    }
+
+    /**
+     * Get providerTeamName
+     *
+     * @return string
+     */
+    public function getProviderTeamName()
+    {
+        return $this->providerTeamName;
+    }
+
+    /**
+     * Set normalizedProviderTeamName
+     *
+     * @param string $normalizedProviderTeamName
+     *
+     * @return OddsProviderTeamMapping
+     */
+    public function setNormalizedProviderTeamName($normalizedProviderTeamName)
+    {
+        $this->normalizedProviderTeamName = $normalizedProviderTeamName;
+
+        return $this;
+    }
+
+    /**
+     * Get normalizedProviderTeamName
+     *
+     * @return string
+     */
+    public function getNormalizedProviderTeamName()
+    {
+        return $this->normalizedProviderTeamName;
+    }
+
+    /**
+     * Set teamId
+     *
+     * @param integer $teamId
+     *
+     * @return OddsProviderTeamMapping
+     */
+    public function setTeamId($teamId)
+    {
+        $this->teamId = $teamId;
+
+        return $this;
+    }
+
+    /**
+     * Get teamId
+     *
+     * @return integer
+     */
+    public function getTeamId()
+    {
+        return $this->teamId;
+    }
+}

--- a/src/Devlabs/SportifyBundle/Entity/OddsProviderTeamMappingRepository.php
+++ b/src/Devlabs/SportifyBundle/Entity/OddsProviderTeamMappingRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Devlabs\SportifyBundle\Entity;
+
+class OddsProviderTeamMappingRepository extends \Doctrine\ORM\EntityRepository
+{
+    public function getByTournamentProviderAndNormalizedName($tournamentId, $provider, $normalizedProviderTeamName)
+    {
+        $query = $this->getEntityManager()->createQueryBuilder()
+            ->select('m')
+            ->from(OddsProviderTeamMapping::class, 'm')
+            ->where('m.tournamentId = :tournament_id')
+            ->andWhere('m.provider = :provider')
+            ->andWhere('m.normalizedProviderTeamName = :normalized_provider_team_name')
+            ->setParameter('tournament_id', $tournamentId)
+            ->setParameter('provider', $provider)
+            ->setParameter('normalized_provider_team_name', $normalizedProviderTeamName);
+
+        try {
+            return $query->getQuery()->getSingleResult();
+        } catch (\Doctrine\ORM\NoResultException $e) {
+            return null;
+        }
+    }
+}

--- a/src/Devlabs/SportifyBundle/Resources/config/services.yml
+++ b/src/Devlabs/SportifyBundle/Resources/config/services.yml
@@ -73,7 +73,7 @@ services:
 
     app.odds.the_odds_api:
         class: Devlabs\SportifyBundle\Services\Odds\TheOddsApi
-        arguments: ['@service_container', '@app.odds_probability_normalizer', '%odds_api.base_uri%', null, '@app.telegram']
+        arguments: ['@service_container', '@app.odds_probability_normalizer', '%odds_api.base_uri%', null, '@app.telegram', '@doctrine.orm.entity_manager']
 
     app.scoring_defaults:
         class: Devlabs\SportifyBundle\Services\ScoringDefaults

--- a/src/Devlabs/SportifyBundle/Services/DataUpdates/Parsers/FootballDataOrg.php
+++ b/src/Devlabs/SportifyBundle/Services/DataUpdates/Parsers/FootballDataOrg.php
@@ -22,6 +22,7 @@ class FootballDataOrg
             $parsedTeam['team_id'] = $team->id;
             $parsedTeam['name'] = $team->name;
             $parsedTeam['team_logo'] = $this->getImageUrl($team, array('crest', 'crestUrl'));
+            $parsedTeam = array_merge($parsedTeam, $this->getTeamMetadata($team));
 
             $team = $parsedTeam;
         }
@@ -46,6 +47,8 @@ class FootballDataOrg
             $parsedFixture['tournament_id'] = $fixture->season->id;
             $parsedFixture['home_team_id'] = $fixture->homeTeam->id;
             $parsedFixture['away_team_id'] = $fixture->awayTeam->id;
+            $parsedFixture = array_merge($parsedFixture, $this->getFixtureTeamMetadata($fixture->homeTeam, 'home'));
+            $parsedFixture = array_merge($parsedFixture, $this->getFixtureTeamMetadata($fixture->awayTeam, 'away'));
 
             // NOTE: v2 used team id 757 as a placeholder, while v4 uses null
             // team ids for unresolved scheduled teams.
@@ -120,6 +123,42 @@ class FootballDataOrg
         $property = property_exists($score, $team) ? $team : $team.'Team';
 
         return $score->$property;
+    }
+
+    private function getFixtureTeamMetadata($team, $prefix)
+    {
+        $metadata = array();
+        foreach ($this->getTeamMetadata($team) as $key => $value) {
+            $metadata[$prefix.'_team_'.$key] = $value;
+        }
+
+        return $metadata;
+    }
+
+    private function getTeamMetadata($team)
+    {
+        $metadata = array();
+        foreach (array('name', 'shortName', 'tla') as $property) {
+            if (property_exists($team, $property) && $team->$property) {
+                $metadata[$this->camelToSnake($property)] = $team->$property;
+            }
+        }
+
+        if (property_exists($team, 'area') && is_object($team->area)) {
+            if (property_exists($team->area, 'name') && $team->area->name) {
+                $metadata['area_name'] = $team->area->name;
+            }
+            if (property_exists($team->area, 'code') && $team->area->code) {
+                $metadata['area_code'] = $team->area->code;
+            }
+        }
+
+        return $metadata;
+    }
+
+    private function camelToSnake($name)
+    {
+        return strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $name));
     }
 
     private function getImageUrl($object, array $properties)

--- a/src/Devlabs/SportifyBundle/Services/Odds/TheOddsApi.php
+++ b/src/Devlabs/SportifyBundle/Services/Odds/TheOddsApi.php
@@ -2,15 +2,18 @@
 
 namespace Devlabs\SportifyBundle\Services\Odds;
 
+use Devlabs\SportifyBundle\Entity\OddsProviderTeamMapping;
 use Devlabs\SportifyBundle\Entity\Team;
 use Devlabs\SportifyBundle\Entity\Tournament;
 use Devlabs\SportifyBundle\Services\Telegram;
+use Doctrine\ORM\EntityManagerInterface;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class TheOddsApi
 {
+    const PROVIDER = 'the_odds_api';
     const REGION = 'eu';
     const MARKET = 'h2h';
     const ODDS_FORMAT = 'decimal';
@@ -22,7 +25,9 @@ class TheOddsApi
     private $baseUri;
     private $normalizer;
     private $telegram;
+    private $entityManager;
     private $activeSportKeys;
+    private $lastEventMatchingReason;
     private $oddsUnavailableNotifications = array();
 
     private $sportKeyCandidates = array(
@@ -41,13 +46,14 @@ class TheOddsApi
 
     private $preferredBookmakers = array('pinnacle', 'betfair', 'williamhill', 'bet365');
 
-    public function __construct(ContainerInterface $container, OddsProbabilityNormalizer $normalizer, $baseUri, ?ClientInterface $httpClient = null, ?Telegram $telegram = null)
+    public function __construct(ContainerInterface $container, OddsProbabilityNormalizer $normalizer, $baseUri, ?ClientInterface $httpClient = null, ?Telegram $telegram = null, ?EntityManagerInterface $entityManager = null)
     {
         $this->container = $container;
         $this->normalizer = $normalizer;
         $this->baseUri = rtrim((string) $baseUri, '/');
         $this->httpClient = $httpClient ?: new Client();
         $this->telegram = $telegram;
+        $this->entityManager = $entityManager;
     }
 
     public function findProbabilitiesForFixture(array $fixtureData, Tournament $tournament, Team $homeTeam, Team $awayTeam)
@@ -67,9 +73,9 @@ class TheOddsApi
                 return null;
             }
 
-            $event = $this->findMatchingEvent($sportKey, $apiToken, $fixtureData, $homeTeam, $awayTeam);
+            $event = $this->findMatchingEvent($sportKey, $apiToken, $fixtureData, $tournament, $homeTeam, $awayTeam);
             if ($event === null || !isset($event->id)) {
-                $this->notifyOddsUnavailable($fixtureData, $tournament, $homeTeam, $awayTeam, 'No matching The Odds API event was found.');
+                $this->notifyOddsUnavailable($fixtureData, $tournament, $homeTeam, $awayTeam, $this->lastEventMatchingReason ?: 'No matching The Odds API event was found.');
 
                 return null;
             }
@@ -86,7 +92,7 @@ class TheOddsApi
                 return null;
             }
 
-            $snapshot = $this->extractSnapshot($oddsEvent, $sportKey, $event->id, $homeTeam, $awayTeam);
+            $snapshot = $this->extractSnapshot($oddsEvent, $sportKey, $event->id, $event->home_team, $event->away_team);
             if ($snapshot === null) {
                 $this->notifyOddsUnavailable($fixtureData, $tournament, $homeTeam, $awayTeam, 'No complete home/draw/away odds snapshot was found.');
             }
@@ -150,10 +156,13 @@ class TheOddsApi
         return isset($this->activeSportKeys[$sportKey]);
     }
 
-    private function findMatchingEvent($sportKey, $apiToken, array $fixtureData, Team $homeTeam, Team $awayTeam)
+    private function findMatchingEvent($sportKey, $apiToken, array $fixtureData, Tournament $tournament, Team $homeTeam, Team $awayTeam)
     {
+        $this->lastEventMatchingReason = 'No matching The Odds API event was found.';
         $matchTime = strtotime($fixtureData['match_local_time']);
         if ($matchTime === false) {
+            $this->lastEventMatchingReason = 'Football-Data fixture kickoff time could not be parsed.';
+
             return null;
         }
 
@@ -166,8 +175,8 @@ class TheOddsApi
             return null;
         }
 
-        $homeName = $this->normalizeName($homeTeam->getName());
-        $awayName = $this->normalizeName($awayTeam->getName());
+        $matches = array();
+        $reasons = array();
         foreach ($events as $event) {
             if (!isset($event->home_team, $event->away_team, $event->commence_time)) {
                 continue;
@@ -177,15 +186,212 @@ class TheOddsApi
                 continue;
             }
 
-            if ($this->normalizeName($event->home_team) === $homeName && $this->normalizeName($event->away_team) === $awayName) {
-                return $event;
+            $teamMatch = $this->matchEventTeams($event, $fixtureData, $tournament, $homeTeam, $awayTeam);
+            if ($teamMatch['matched']) {
+                $matches[] = array('event' => $event, 'mappings' => $teamMatch['mappings']);
+            } elseif ($teamMatch['reason'] !== '') {
+                $reasons[] = $teamMatch['reason'];
             }
+        }
+
+        if (count($matches) === 1) {
+            $this->persistLearnedMappings($matches[0]['mappings'], $tournament);
+
+            return $matches[0]['event'];
+        }
+
+        if (count($matches) > 1) {
+            $this->lastEventMatchingReason = 'Ambiguous The Odds API event match: multiple events matched the Football-Data kickoff and team metadata.';
+
+            return null;
+        }
+
+        if ($reasons) {
+            $this->lastEventMatchingReason = 'No safely matched The Odds API event was found. '.$this->summarizeReasons($reasons);
         }
 
         return null;
     }
 
-    private function extractSnapshot($event, $sportKey, $eventId, Team $homeTeam, Team $awayTeam)
+    private function matchEventTeams($event, array $fixtureData, Tournament $tournament, Team $homeTeam, Team $awayTeam)
+    {
+        $homeMatch = $this->matchProviderTeamNameToFixtureSide($event->home_team, $fixtureData, $tournament, $homeTeam, $awayTeam, 'home');
+        $awayMatch = $this->matchProviderTeamNameToFixtureSide($event->away_team, $fixtureData, $tournament, $homeTeam, $awayTeam, 'away');
+
+        if ($homeMatch['matched'] && $awayMatch['matched']) {
+            return array(
+                'matched' => true,
+                'mappings' => array_merge($homeMatch['mappings'], $awayMatch['mappings']),
+                'reason' => '',
+            );
+        }
+
+        $reason = 'Event "'.$event->home_team.' vs '.$event->away_team.'": ';
+        $sideReasons = array();
+        if (!$homeMatch['matched'] && $homeMatch['reason'] !== '') {
+            $sideReasons[] = $homeMatch['reason'];
+        }
+        if (!$awayMatch['matched'] && $awayMatch['reason'] !== '') {
+            $sideReasons[] = $awayMatch['reason'];
+        }
+
+        return array('matched' => false, 'mappings' => array(), 'reason' => $reason.implode(' ', $sideReasons));
+    }
+
+    private function matchProviderTeamNameToFixtureSide($providerTeamName, array $fixtureData, Tournament $tournament, Team $homeTeam, Team $awayTeam, $expectedSide)
+    {
+        $expectedTeam = $expectedSide === 'home' ? $homeTeam : $awayTeam;
+        $mappedTeamId = $this->getMappedTeamId($tournament, $providerTeamName);
+        if ($mappedTeamId !== null) {
+            if ((int) $mappedTeamId === (int) $expectedTeam->getId()) {
+                return array('matched' => true, 'mappings' => array(), 'reason' => '');
+            }
+
+            return array(
+                'matched' => false,
+                'mappings' => array(),
+                'reason' => 'Provider team "'.$providerTeamName.'" is already mapped to "'.$this->getTeamNameById($mappedTeamId).'", not fixture '.$expectedSide.' team "'.$expectedTeam->getName().'".',
+            );
+        }
+
+        $normalizedProviderTeamName = $this->normalizeName($providerTeamName);
+        $matchingSides = array();
+        foreach (array('home' => $homeTeam, 'away' => $awayTeam) as $side => $team) {
+            $candidateNames = $this->getTeamCandidateNames($fixtureData, $side, $team);
+            if (isset($candidateNames[$normalizedProviderTeamName])) {
+                $matchingSides[] = $side;
+            }
+        }
+
+        if (count($matchingSides) > 1) {
+            return array(
+                'matched' => false,
+                'mappings' => array(),
+                'reason' => 'Provider team "'.$providerTeamName.'" ambiguously matches both Football-Data fixture teams.',
+            );
+        }
+
+        if (!$matchingSides) {
+            return array(
+                'matched' => false,
+                'mappings' => array(),
+                'reason' => 'Missing The Odds API team mapping for provider team "'.$providerTeamName.'".',
+            );
+        }
+
+        if ($matchingSides[0] !== $expectedSide) {
+            $matchedTeam = $matchingSides[0] === 'home' ? $homeTeam : $awayTeam;
+
+            return array(
+                'matched' => false,
+                'mappings' => array(),
+                'reason' => 'Provider team "'.$providerTeamName.'" matches Football-Data metadata for "'.$matchedTeam->getName().'", not fixture '.$expectedSide.' team "'.$expectedTeam->getName().'".',
+            );
+        }
+
+        $mappings = array();
+        if ($tournament->getId() !== null && $expectedTeam->getId() !== null) {
+            $mappings[] = array(
+                'provider_team_name' => $providerTeamName,
+                'normalized_provider_team_name' => $normalizedProviderTeamName,
+                'team_id' => $expectedTeam->getId(),
+            );
+        }
+
+        return array('matched' => true, 'mappings' => $mappings, 'reason' => '');
+    }
+
+    private function getMappedTeamId(Tournament $tournament, $providerTeamName)
+    {
+        $mapping = $this->getProviderTeamMapping($tournament, $providerTeamName);
+
+        return $mapping === null ? null : $mapping->getTeamId();
+    }
+
+    private function getProviderTeamMapping(Tournament $tournament, $providerTeamName)
+    {
+        if ($this->entityManager === null || $tournament->getId() === null) {
+            return null;
+        }
+
+        return $this->entityManager->getRepository(OddsProviderTeamMapping::class)
+            ->getByTournamentProviderAndNormalizedName($tournament->getId(), self::PROVIDER, $this->normalizeName($providerTeamName));
+    }
+
+    private function persistLearnedMappings(array $mappings, Tournament $tournament)
+    {
+        if ($this->entityManager === null || $tournament->getId() === null) {
+            return;
+        }
+
+        $persisted = false;
+        foreach ($mappings as $mappingData) {
+            $existingMapping = $this->entityManager->getRepository(OddsProviderTeamMapping::class)
+                ->getByTournamentProviderAndNormalizedName($tournament->getId(), self::PROVIDER, $mappingData['normalized_provider_team_name']);
+            if ($existingMapping !== null) {
+                continue;
+            }
+
+            $mapping = new OddsProviderTeamMapping();
+            $mapping->setTournamentId($tournament->getId());
+            $mapping->setProvider(self::PROVIDER);
+            $mapping->setProviderTeamName($mappingData['provider_team_name']);
+            $mapping->setNormalizedProviderTeamName($mappingData['normalized_provider_team_name']);
+            $mapping->setTeamId($mappingData['team_id']);
+
+            $this->entityManager->persist($mapping);
+            $persisted = true;
+        }
+
+        if ($persisted) {
+            $this->entityManager->flush();
+        }
+    }
+
+    private function getTeamNameById($teamId)
+    {
+        if ($this->entityManager === null) {
+            return '#'.$teamId;
+        }
+
+        $team = $this->entityManager->getRepository(Team::class)->find($teamId);
+
+        return $team === null ? '#'.$teamId : $team->getName();
+    }
+
+    private function summarizeReasons(array $reasons)
+    {
+        $uniqueReasons = array_values(array_unique($reasons));
+        $text = implode(' ', array_slice($uniqueReasons, 0, 3));
+        if (count($uniqueReasons) > 3) {
+            $text .= ' ...and '.(count($uniqueReasons) - 3).' more candidate event(s).';
+        }
+
+        return $text;
+    }
+
+    private function getTeamCandidateNames(array $fixtureData, $side, Team $team)
+    {
+        $names = array($team->getName());
+        foreach (array('name', 'short_name', 'tla', 'area_name', 'area_code') as $field) {
+            $key = $side.'_team_'.$field;
+            if (isset($fixtureData[$key]) && $fixtureData[$key]) {
+                $names[] = $fixtureData[$key];
+            }
+        }
+
+        $candidateNames = array();
+        foreach ($names as $name) {
+            $normalizedName = $this->normalizeName($name);
+            if ($normalizedName !== '') {
+                $candidateNames[$normalizedName] = $name;
+            }
+        }
+
+        return $candidateNames;
+    }
+
+    private function extractSnapshot($event, $sportKey, $eventId, $providerHomeTeamName, $providerAwayTeamName)
     {
         if (!isset($event->bookmakers) || !is_array($event->bookmakers)) {
             return null;
@@ -193,7 +399,7 @@ class TheOddsApi
 
         $bookmakers = $this->sortBookmakers($event->bookmakers);
         foreach ($bookmakers as $bookmaker) {
-            $prices = $this->extractPrices($bookmaker, $homeTeam, $awayTeam);
+            $prices = $this->extractPrices($bookmaker, $providerHomeTeamName, $providerAwayTeamName);
             if ($prices === null) {
                 continue;
             }
@@ -204,7 +410,7 @@ class TheOddsApi
             }
 
             $bookmakerKey = isset($bookmaker->key) ? $bookmaker->key : 'unknown';
-            $probabilities['source'] = 'the_odds_api:'.$sportKey.':'.$eventId.':'.$bookmakerKey.':h2h';
+            $probabilities['source'] = self::PROVIDER.':'.$sportKey.':'.$eventId.':'.$bookmakerKey.':h2h';
 
             return $probabilities;
         }
@@ -229,7 +435,7 @@ class TheOddsApi
         return $rank === false ? 100 : $rank;
     }
 
-    private function extractPrices($bookmaker, Team $homeTeam, Team $awayTeam)
+    private function extractPrices($bookmaker, $providerHomeTeamName, $providerAwayTeamName)
     {
         if (!isset($bookmaker->markets) || !is_array($bookmaker->markets)) {
             return null;
@@ -241,8 +447,8 @@ class TheOddsApi
             }
 
             $prices = array('home' => null, 'draw' => null, 'away' => null);
-            $homeName = $this->normalizeName($homeTeam->getName());
-            $awayName = $this->normalizeName($awayTeam->getName());
+            $homeName = $this->normalizeName($providerHomeTeamName);
+            $awayName = $this->normalizeName($providerAwayTeamName);
             foreach ($market->outcomes as $outcome) {
                 if (!isset($outcome->name, $outcome->price)) {
                     continue;

--- a/tests/Integration/OddsProviderTeamMappingTest.php
+++ b/tests/Integration/OddsProviderTeamMappingTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\Integration;
+
+require_once __DIR__.'/DatabaseTestCase.php';
+
+use Devlabs\SportifyBundle\Entity\OddsProviderTeamMapping;
+use Devlabs\SportifyBundle\Services\Odds\OddsProbabilityNormalizer;
+use Devlabs\SportifyBundle\Services\Odds\TheOddsApi;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Symfony\Component\DependencyInjection\Container;
+
+class OddsProviderTeamMappingTest extends DatabaseTestCase
+{
+    public function testAutoLearnsAndReusesProviderTeamMappings()
+    {
+        $tournament = $this->createTournament('FIFA World Cup');
+        $homeTeam = $this->createTeam('United States', $tournament);
+        $awayTeam = $this->createTeam('South Africa', $tournament);
+        $api = $this->createApi(array(
+            $this->sportsResponse(),
+            $this->eventsResponse('USA', 'RSA'),
+            $this->oddsResponse('USA', 'RSA'),
+            $this->eventsResponse('USA', 'RSA'),
+            $this->oddsResponse('USA', 'RSA'),
+        ));
+
+        $fixtureData = $this->fixtureData(array(
+            'home_team_name' => 'United States',
+            'home_team_short_name' => 'USA',
+            'home_team_tla' => 'USA',
+            'home_team_area_name' => 'United States',
+            'home_team_area_code' => 'USA',
+            'away_team_name' => 'South Africa',
+            'away_team_short_name' => 'RSA',
+            'away_team_tla' => 'RSA',
+            'away_team_area_name' => 'South Africa',
+            'away_team_area_code' => 'RSA',
+        ));
+
+        $this->assertNotNull($api->findProbabilitiesForFixture($fixtureData, $tournament, $homeTeam, $awayTeam));
+
+        $usaMapping = $this->em->getRepository(OddsProviderTeamMapping::class)
+            ->getByTournamentProviderAndNormalizedName($tournament->getId(), TheOddsApi::PROVIDER, 'usa');
+        $rsaMapping = $this->em->getRepository(OddsProviderTeamMapping::class)
+            ->getByTournamentProviderAndNormalizedName($tournament->getId(), TheOddsApi::PROVIDER, 'rsa');
+
+        $this->assertSame($homeTeam->getId(), $usaMapping->getTeamId());
+        $this->assertSame($awayTeam->getId(), $rsaMapping->getTeamId());
+
+        $this->assertNotNull($api->findProbabilitiesForFixture($this->fixtureData(), $tournament, $homeTeam, $awayTeam));
+    }
+
+    private function createApi(array $responses)
+    {
+        $container = new Container();
+        $container->setParameter('odds_api.token', 'test-token');
+        $client = new Client(array('handler' => HandlerStack::create(new MockHandler($responses))));
+
+        return new TheOddsApi($container, new OddsProbabilityNormalizer(), 'https://api.example.test', $client, null, $this->em);
+    }
+
+    private function sportsResponse()
+    {
+        return new Response(200, array(), json_encode(array(
+            array('key' => 'soccer_fifa_world_cup'),
+        )));
+    }
+
+    private function eventsResponse($homeTeam, $awayTeam)
+    {
+        return new Response(200, array(), json_encode(array(
+            array(
+                'id' => 'event-1',
+                'commence_time' => '2026-06-11T19:00:00Z',
+                'home_team' => $homeTeam,
+                'away_team' => $awayTeam,
+            ),
+        )));
+    }
+
+    private function oddsResponse($homeTeam, $awayTeam)
+    {
+        return new Response(200, array(), json_encode(array(
+            'id' => 'event-1',
+            'bookmakers' => array(
+                array(
+                    'key' => 'pinnacle',
+                    'markets' => array(
+                        array(
+                            'key' => 'h2h',
+                            'outcomes' => array(
+                                array('name' => $homeTeam, 'price' => 2.0),
+                                array('name' => 'Draw', 'price' => 4.0),
+                                array('name' => $awayTeam, 'price' => 4.0),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )));
+    }
+
+    private function fixtureData(array $data = array())
+    {
+        return array_merge(array(
+            'match_id' => 500,
+            'match_local_time' => '2026-06-11 19:00:00',
+        ), $data);
+    }
+}

--- a/tests/Unit/FootballDataOrgParserTest.php
+++ b/tests/Unit/FootballDataOrgParserTest.php
@@ -88,6 +88,37 @@ class FootballDataOrgParserTest extends \PHPUnit\Framework\TestCase
         ), $parsed[1]);
     }
 
+    public function testParseFixturesIncludesTeamMatchingMetadataWhenPresent()
+    {
+        $fixture = $this->createFixture(1, 'SCHEDULED', '2020-01-02T12:00:00Z');
+        $fixture->homeTeam->name = 'United States';
+        $fixture->homeTeam->shortName = 'USA';
+        $fixture->homeTeam->tla = 'USA';
+        $fixture->homeTeam->area = new \stdClass();
+        $fixture->homeTeam->area->name = 'United States';
+        $fixture->homeTeam->area->code = 'USA';
+        $fixture->awayTeam->name = 'South Africa';
+        $fixture->awayTeam->shortName = 'RSA';
+        $fixture->awayTeam->tla = 'RSA';
+        $fixture->awayTeam->area = new \stdClass();
+        $fixture->awayTeam->area->name = 'South Africa';
+        $fixture->awayTeam->area->code = 'RSA';
+
+        $parser = new FootballDataOrg();
+        $parsed = $parser->parseFixtures(array($fixture));
+
+        $this->assertSame('United States', $parsed[0]['home_team_name']);
+        $this->assertSame('USA', $parsed[0]['home_team_short_name']);
+        $this->assertSame('USA', $parsed[0]['home_team_tla']);
+        $this->assertSame('United States', $parsed[0]['home_team_area_name']);
+        $this->assertSame('USA', $parsed[0]['home_team_area_code']);
+        $this->assertSame('South Africa', $parsed[0]['away_team_name']);
+        $this->assertSame('RSA', $parsed[0]['away_team_short_name']);
+        $this->assertSame('RSA', $parsed[0]['away_team_tla']);
+        $this->assertSame('South Africa', $parsed[0]['away_team_area_name']);
+        $this->assertSame('RSA', $parsed[0]['away_team_area_code']);
+    }
+
     public function testParseFixturesAcceptsV4ScoreProperties()
     {
         $finished = $this->createFixture(2, 'FINISHED', '2020-01-03T12:00:00Z', 4, 3, null, null, null, null, true);

--- a/tests/Unit/TheOddsApiTest.php
+++ b/tests/Unit/TheOddsApiTest.php
@@ -42,6 +42,64 @@ class TheOddsApiTest extends TestCase
         ));
     }
 
+    public function testMatchesProviderTeamsWithFootballDataMetadata()
+    {
+        $api = $this->createApi(array(
+            $this->sportsResponse(),
+            $this->eventsResponse('USA', 'RSA'),
+            $this->oddsResponse(array(
+                array('name' => 'USA', 'price' => 2.0),
+                array('name' => 'Draw', 'price' => 4.0),
+                array('name' => 'RSA', 'price' => 4.0),
+            )),
+        ));
+
+        $this->assertSame(array(
+            'home_win_probability_percent' => 50,
+            'draw_probability_percent' => 25,
+            'away_win_probability_percent' => 25,
+            'source' => 'the_odds_api:soccer_fifa_world_cup:event-1:pinnacle:h2h',
+        ), $api->findProbabilitiesForFixture(
+            $this->fixtureData(500, array(
+                'home_team_name' => 'United States',
+                'home_team_short_name' => 'USA',
+                'home_team_tla' => 'USA',
+                'home_team_area_name' => 'United States',
+                'home_team_area_code' => 'USA',
+                'away_team_name' => 'South Africa',
+                'away_team_short_name' => 'RSA',
+                'away_team_tla' => 'RSA',
+                'away_team_area_name' => 'South Africa',
+                'away_team_area_code' => 'RSA',
+            )),
+            $this->tournament(),
+            $this->team('United States'),
+            $this->team('South Africa')
+        ));
+    }
+
+    public function testNotifiesAdminWhenProviderTeamMappingIsMissing()
+    {
+        $telegram = new FakeTheOddsApiAdminTelegram();
+        $api = $this->createApi(array(
+            $this->sportsResponse(),
+            $this->eventsResponse('USA', 'South Africa'),
+        ), 'test-token', $telegram);
+
+        $this->assertNull($api->findProbabilitiesForFixture(
+            $this->fixtureData(),
+            $this->tournament(),
+            $this->team('United States'),
+            $this->team('South Africa')
+        ));
+
+        $api->flushOddsUnavailableNotifications();
+
+        $this->assertCount(1, $telegram->adminMessages);
+        $this->assertStringContainsString('Reason: No safely matched The Odds API event was found.', $telegram->adminMessages[0]);
+        $this->assertStringContainsString('Missing The Odds API team mapping for provider team "USA".', $telegram->adminMessages[0]);
+    }
+
     public function testThrowsWhenOddsEndpointFails()
     {
         $telegram = new FakeTheOddsApiAdminTelegram();
@@ -195,14 +253,14 @@ class TheOddsApiTest extends TestCase
         )));
     }
 
-    private function eventsResponse()
+    private function eventsResponse($homeTeam = 'Mexico', $awayTeam = 'South Africa')
     {
         return new Response(200, array(), json_encode(array(
             array(
                 'id' => 'event-1',
                 'commence_time' => '2026-06-11T19:00:00Z',
-                'home_team' => 'Mexico',
-                'away_team' => 'South Africa',
+                'home_team' => $homeTeam,
+                'away_team' => $awayTeam,
             ),
         )));
     }
@@ -225,12 +283,12 @@ class TheOddsApiTest extends TestCase
         )));
     }
 
-    private function fixtureData($matchId = 500)
+    private function fixtureData($matchId = 500, array $data = array())
     {
-        return array(
+        return array_merge(array(
             'match_id' => $matchId,
             'match_local_time' => '2026-06-11 19:00:00',
-        );
+        ), $data);
     }
 
     private function tournament()


### PR DESCRIPTION
Implements reusable The Odds API team-name mappings for fixture odds imports and safer matching notifications.