### PR TITLE
Add TODO for DB-gated match results updates

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,11 +2,11 @@
 
 ## Current status
 
-Pending task: none currently tracked.
+Pending task: reduce unnecessary match-results API calls by checking local result-update candidates before querying football-data.org.
 
 ## Pending
 
-- None.
+- Update `update matches-results` so it checks the local database first and skips football-data.org when the database indicates nothing can possibly need result updates.
 
 ## Baseline
 


### PR DESCRIPTION
Adds a TODO to reduce football-data.org match-results calls by checking local update candidates first.