### PR TITLE
Skip match result API calls when no local updates are possible

### DIFF
--- a/src/Devlabs/SportifyBundle/Command/DataUpdateCommand.php
+++ b/src/Devlabs/SportifyBundle/Command/DataUpdateCommand.php
@@ -71,7 +71,7 @@ class DataUpdateCommand extends Command
             // set dateFrom and dateTo to respectively 'number of days' before and today
             $dateFrom = date("Y-m-d", time() - (3600 * 24 * $days));
             $dateTo = date("Y-m-d");
-            $status = $dataUpdatesManager->updateFixtures($dateFrom, $dateTo);
+            $status = $dataUpdatesManager->updateResults($dateFrom, $dateTo);
 
             if ($status['total_updated'] > 0) {
                 $em = $this->container->get('doctrine.orm.entity_manager');

--- a/src/Devlabs/SportifyBundle/Entity/MatchRepository.php
+++ b/src/Devlabs/SportifyBundle/Entity/MatchRepository.php
@@ -83,6 +83,31 @@ class MatchRepository extends \Doctrine\ORM\EntityRepository
     }
 
     /**
+     * Check if local matches can need final result updates.
+     *
+     * @param $dateFrom
+     * @param $dateTo
+     * @param \DateTime $now
+     * @return bool
+     */
+    public function hasResultUpdateCandidates($dateFrom, $dateTo, \DateTime $now)
+    {
+        $count = $this->getEntityManager()->createQueryBuilder()
+            ->select('COUNT(m.id)')
+            ->from(MatchEntity::class, 'm')
+            ->where('m.homeGoals IS NULL OR m.awayGoals IS NULL')
+            ->andWhere('m.datetime >= :date_from AND m.datetime <= :date_to')
+            ->andWhere('m.datetime <= :now')
+            ->setParameter('date_from', $dateFrom)
+            ->setParameter('date_to', $dateTo)
+            ->setParameter('now', $now)
+            ->getQuery()
+            ->getSingleScalarResult();
+
+        return (int) $count > 0;
+    }
+
+    /**
      * Get a list of matches which have final score
      * but there are NOT SCORED predictions for these matches
      *

--- a/src/Devlabs/SportifyBundle/Services/ControllerHelpers/AdminHelper.php
+++ b/src/Devlabs/SportifyBundle/Services/ControllerHelpers/AdminHelper.php
@@ -94,7 +94,7 @@ class AdminHelper
             // set dateFrom and dateTo to respectively 'number of days' before and today
             $dateFrom = date("Y-m-d", time() - (3600 * 24 * $data['days']));
             $dateTo = date("Y-m-d");
-            $status = $dataUpdatesManager->updateFixtures($dateFrom, $dateTo);
+            $status = $dataUpdatesManager->updateResults($dateFrom, $dateTo);
 
             if ($status['total_updated'] > 0) {
                 // Get the ScoreUpdater service and update all scores

--- a/src/Devlabs/SportifyBundle/Services/DataUpdates/Manager.php
+++ b/src/Devlabs/SportifyBundle/Services/DataUpdates/Manager.php
@@ -6,6 +6,7 @@ use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Doctrine\ORM\EntityManager;
 use Devlabs\SportifyBundle\Entity\ApiMapping;
+use Devlabs\SportifyBundle\Entity\MatchEntity;
 use Devlabs\SportifyBundle\Entity\Tournament;
 
 /**
@@ -69,17 +70,28 @@ class Manager
         $this->dataImporter->importTeams($parsedTeams, $tournament, $this->footballApi);
     }
 
+    public function updateResults($dateFrom, $dateTo)
+    {
+        $status = $this->createFixturesStatus();
+
+        if (!$this->em->getRepository(MatchEntity::class)->hasResultUpdateCandidates(
+            $this->createDateTime($dateFrom, false),
+            $this->createDateTime($dateTo, true),
+            new \DateTime()
+        )) {
+            return $status;
+        }
+
+        return $this->updateFixtures($dateFrom, $dateTo);
+    }
+
     /**
      * Update fixtures data via API Fetch, Parse and Import services
      * for a given time range (start date and end date)
      */
     public function updateFixtures($dateFrom, $dateTo)
     {
-        $status = array();
-        $status['total_fetched'] = 0;
-        $status['total_added'] = 0;
-        $status['total_updated'] = 0;
-        $status['added_fixtures'] = array();
+        $status = $this->createFixturesStatus();
 
         // get all tournaments
         $tournaments = $this->em->getRepository(Tournament::class)->findAll();
@@ -118,6 +130,30 @@ class Manager
         }
 
         return $status;
+    }
+
+    private function createFixturesStatus()
+    {
+        return array(
+            'total_fetched' => 0,
+            'total_added' => 0,
+            'total_updated' => 0,
+            'added_fixtures' => array(),
+        );
+    }
+
+    private function createDateTime($date, $endOfDay)
+    {
+        if ($date instanceof \DateTime) {
+            return $date;
+        }
+
+        if (strpos($date, ' ') !== false) {
+            return new \DateTime($date);
+        }
+
+        $time = $endOfDay ? '23:59:59' : '00:00:00';
+        return new \DateTime($date.' '.$time);
     }
 
     /**

--- a/tests/Unit/DataUpdateCommandTest.php
+++ b/tests/Unit/DataUpdateCommandTest.php
@@ -202,7 +202,7 @@ class FakeDataUpdatesManager
 
 class FakeResultsDataUpdatesManager
 {
-    public function updateFixtures($dateFrom, $dateTo)
+    public function updateResults($dateFrom, $dateTo)
     {
         return array(
             'total_added' => 0,

--- a/tests/Unit/DataUpdatesManagerTest.php
+++ b/tests/Unit/DataUpdatesManagerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Unit;
+
+use Devlabs\SportifyBundle\Entity\MatchEntity;
+use Devlabs\SportifyBundle\Entity\MatchRepository;
+use Devlabs\SportifyBundle\Services\DataUpdates\Manager;
+use Doctrine\ORM\EntityManager;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Container;
+
+class DataUpdatesManagerTest extends TestCase
+{
+    public function testUpdateResultsSkipsApiWhenLocalDatabaseHasNoCandidates()
+    {
+        $matchRepository = $this->createMock(MatchRepository::class);
+        $matchRepository->expects($this->once())
+            ->method('hasResultUpdateCandidates')
+            ->with(
+                $this->callback(function ($date) {
+                    return $date instanceof \DateTime && $date->format('Y-m-d H:i:s') === '2026-06-01 00:00:00';
+                }),
+                $this->callback(function ($date) {
+                    return $date instanceof \DateTime && $date->format('Y-m-d H:i:s') === '2026-06-10 23:59:59';
+                }),
+                $this->isInstanceOf(\DateTime::class)
+            )
+            ->willReturn(false);
+
+        $entityManager = $this->createMock(EntityManager::class);
+        $entityManager->expects($this->once())
+            ->method('getRepository')
+            ->with(MatchEntity::class)
+            ->willReturn($matchRepository);
+
+        $fetcher = new FakeDataUpdatesManagerFetcher();
+        $manager = new Manager(
+            new Container(),
+            $entityManager,
+            'football-data',
+            $fetcher,
+            new FakeDataUpdatesManagerParser(),
+            new FakeDataUpdatesManagerImporter()
+        );
+
+        $status = $manager->updateResults('2026-06-01', '2026-06-10');
+
+        $this->assertSame(array(
+            'total_fetched' => 0,
+            'total_added' => 0,
+            'total_updated' => 0,
+            'added_fixtures' => array(),
+        ), $status);
+        $this->assertFalse($fetcher->fixturesFetched);
+    }
+}
+
+class FakeDataUpdatesManagerFetcher
+{
+    public $fixturesFetched = false;
+
+    public function fetchFixturesByTournamentAndTimeRange($apiTournamentId, $dateFrom, $dateTo)
+    {
+        $this->fixturesFetched = true;
+
+        return array();
+    }
+}
+
+class FakeDataUpdatesManagerParser
+{
+}
+
+class FakeDataUpdatesManagerImporter
+{
+}


### PR DESCRIPTION
Checks local unfinished matches before querying football-data.org for result updates.