### PR TITLE
Fix Telegram pinning default

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,11 +2,11 @@
 
 ## Current status
 
-Pending tasks: 1.
+Pending tasks: 0.
 
 ## Pending
 
-- Clarify and improve Telegram message pinning: document that `telegram.pin_messages` currently applies only to `sportify:data:update` fixture/result notifications, log pin failures, and decide whether prediction/manual Telegram messages should support pinning too.
+None.
 
 ## Baseline
 

--- a/src/Devlabs/SportifyBundle/Command/DataUpdateCommand.php
+++ b/src/Devlabs/SportifyBundle/Command/DataUpdateCommand.php
@@ -130,7 +130,14 @@ class DataUpdateCommand extends Command
                 $telegramResult = json_decode((string) $telegramResponse->getBody(), true);
 
                 if ($this->shouldPinTelegramMessages() && isset($telegramResult['result']['message_id'])) {
-                    $telegram->pinMessage($telegramResult['result']['message_id']);
+                    $pinResponse = $telegram->pinMessage($telegramResult['result']['message_id']);
+                    if ($pinResponse->getStatusCode() < 200 || $pinResponse->getStatusCode() >= 300) {
+                        error_log(sprintf(
+                            'Telegram message pinning failed (HTTP %d %s).',
+                            $pinResponse->getStatusCode(),
+                            $pinResponse->getReasonPhrase()
+                        ));
+                    }
                 }
             }
         } else {
@@ -237,6 +244,11 @@ class DataUpdateCommand extends Command
             return true;
         }
 
-        return filter_var($this->container->getParameter('telegram.pin_messages'), FILTER_VALIDATE_BOOLEAN);
+        $value = $this->container->getParameter('telegram.pin_messages');
+        if ($value === null || $value === '') {
+            return true;
+        }
+
+        return filter_var($value, FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/tests/Unit/DataUpdateCommandTest.php
+++ b/tests/Unit/DataUpdateCommandTest.php
@@ -39,6 +39,26 @@ class DataUpdateCommandTest extends TestCase
         $this->assertSame(array(321), $telegram->pinnedMessageIds);
     }
 
+    public function testBlankTelegramPinningParameterUsesDefault()
+    {
+        $container = new Container();
+        $slack = new FakeDataUpdateSlack();
+        $telegram = new FakeDataUpdateTelegram();
+
+        $this->configureContainer($container, $slack, $telegram);
+        $container->setParameter('telegram.pin_messages', null);
+
+        $tester = new CommandTester(new DataUpdateCommand($container));
+        $tester->execute(array(
+            'type' => 'matches-fixtures',
+            'days' => 3,
+        ));
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertCount(1, $telegram->messages);
+        $this->assertSame(array(321), $telegram->pinnedMessageIds);
+    }
+
     public function testCanDisableTelegramMessagePinning()
     {
         $container = new Container();


### PR DESCRIPTION
Fixes Telegram data update pinning default handling and logs pin failures.