### PR TITLE
Document prediction CSRF rejection work

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,11 +2,22 @@
 
 ## Current status
 
-Pending tasks: 0.
+Pending tasks: 2.
 
 ## Pending
 
-None.
+For each of the following two items only, add a focused test first, run it and confirm that it fails for the expected reason, implement the fix, then run the test again and confirm that it passes.
+
+1. Log rejected prediction-form CSRF metadata server-side.
+   - Log a warning event such as `prediction_csrf_rejected` with the authenticated user ID, match ID, route, whether a CSRF token was present, whether the session was started, and whether the session cookie was present.
+   - Never log the CSRF token or its fingerprint, prediction values, cookies, session ID, request body, passwords, or authentication headers.
+   - Detect the Symfony CSRF form error by type rather than matching its translated message, and do not serialize the error cause because it contains the submitted token.
+
+2. Return explicit prediction-form error responses instead of silently redirecting.
+   - Return HTTP 403 with a dedicated error page when CSRF validation fails.
+   - Clearly state that the prediction was not saved and provide a prominent GET link back to the same filtered Matches page so the user receives a fresh form and token before entering the prediction again. Do not tell the user to refresh the 403 POST response because that would resubmit the stale request.
+   - Return HTTP 422 with equivalent retry guidance for other prediction-form validation failures.
+   - Keep successful prediction submissions unchanged: save and redirect normally without a success notification.
 
 ## Baseline
 


### PR DESCRIPTION
Add TODO items for safe CSRF rejection logging and explicit prediction error responses, with scoped test-first requirements.