### PR TITLE
Log rejected prediction CSRF metadata

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,18 +2,13 @@
 
 ## Current status
 
-Pending tasks: 2.
+Pending tasks: 1.
 
 ## Pending
 
-For each of the following two items only, add a focused test first, run it and confirm that it fails for the expected reason, implement the fix, then run the test again and confirm that it passes.
+For the following item, add a focused test first, run it and confirm that it fails for the expected reason, implement the fix, then run the test again and confirm that it passes.
 
-1. Log rejected prediction-form CSRF metadata server-side.
-   - Log a warning event such as `prediction_csrf_rejected` with the authenticated user ID, match ID, route, whether a CSRF token was present, whether the session was started, and whether the session cookie was present.
-   - Never log the CSRF token or its fingerprint, prediction values, cookies, session ID, request body, passwords, or authentication headers.
-   - Detect the Symfony CSRF form error by type rather than matching its translated message, and do not serialize the error cause because it contains the submitted token.
-
-2. Return explicit prediction-form error responses instead of silently redirecting.
+1. Return explicit prediction-form error responses instead of silently redirecting.
    - Return HTTP 403 with a dedicated error page when CSRF validation fails.
    - Clearly state that the prediction was not saved and provide a prominent GET link back to the same filtered Matches page so the user receives a fresh form and token before entering the prediction again. Do not tell the user to refresh the 403 POST response because that would resubmit the stale request.
    - Return HTTP 422 with equivalent retry guidance for other prediction-form validation failures.

--- a/TODO.md
+++ b/TODO.md
@@ -2,17 +2,21 @@
 
 ## Current status
 
-Pending tasks: 1.
+Pending tasks: 2.
 
 ## Pending
 
-For the following item, add a focused test first, run it and confirm that it fails for the expected reason, implement the fix, then run the test again and confirm that it passes.
+For each of the following two items only, add a focused test first, run it and confirm that it fails for the expected reason, implement the fix, then run the test again and confirm that it passes.
 
 1. Return explicit prediction-form error responses instead of silently redirecting.
    - Return HTTP 403 with a dedicated error page when CSRF validation fails.
    - Clearly state that the prediction was not saved and provide a prominent GET link back to the same filtered Matches page so the user receives a fresh form and token before entering the prediction again. Do not tell the user to refresh the 403 POST response because that would resubmit the stale request.
    - Return HTTP 422 with equivalent retry guidance for other prediction-form validation failures.
    - Keep successful prediction submissions unchanged: save and redirect normally without a success notification.
+
+2. Route remaining direct PHP runtime logging through the application logger.
+   - Replace the `error_log()` calls in `DataUpdateCommand` and `Telegram` with injected PSR logger warning events.
+   - Keep the existing HTTP status, reason, and exception-class diagnostics without logging response bodies, bot tokens, chat IDs, message contents, or exception messages.
 
 ## Baseline
 

--- a/config/packages/monolog.yml
+++ b/config/packages/monolog.yml
@@ -1,0 +1,2 @@
+monolog:
+    channels: ['prediction']

--- a/config/packages/prod/monolog.yml
+++ b/config/packages/prod/monolog.yml
@@ -4,6 +4,12 @@ monolog:
             type:         fingers_crossed
             action_level: error
             handler:      nested
+            channels:     ['!prediction']
+        prediction_rejections:
+            type:     stream
+            path:     "%kernel.logs_dir%/%kernel.environment%.log"
+            level:    warning
+            channels: ['prediction']
         nested:
             type:  stream
             path:  "%kernel.logs_dir%/%kernel.environment%.log"

--- a/config/packages/test/monolog.yml
+++ b/config/packages/test/monolog.yml
@@ -8,3 +8,7 @@ monolog:
         console:
             type:   console
             channels: ['!event', '!doctrine']
+        test:
+            type: test
+            level: warning
+            channels: ['!event']

--- a/src/Devlabs/SportifyBundle/Controller/MatchesController.php
+++ b/src/Devlabs/SportifyBundle/Controller/MatchesController.php
@@ -4,8 +4,10 @@ namespace Devlabs\SportifyBundle\Controller;
 
 use Devlabs\SportifyBundle\Entity\MatchEntity;
 use Devlabs\SportifyBundle\Entity\Prediction;
+use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Csrf\CsrfToken;
 
 /**
  * Class MatchesController
@@ -13,6 +15,13 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class MatchesController extends AbstractController
 {
+    private $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
     public function indexAction(Request $request, $tournament_id, $date_from, $date_to)
     {
         // if user is not logged in, redirect to login page
@@ -131,6 +140,26 @@ class MatchesController extends AbstractController
                 return $this->redirectToRoute('matches_index', $urlParams);
 
             $matchesHelper->actionOnFormSubmit($form);
+        }
+
+        if ($form->isSubmitted() && !$form->isValid()) {
+            foreach ($form->getErrors(true) as $error) {
+                if (!($error->getCause() instanceof CsrfToken)) {
+                    continue;
+                }
+
+                $session = $request->hasSession() ? $request->getSession() : null;
+                $this->logger->warning('prediction_csrf_rejected', array(
+                    'user_id' => $user->getId(),
+                    'match_id' => $match->getId(),
+                    'route' => $request->attributes->get('_route'),
+                    'csrf_token_present' => array_key_exists('_token', $submittedPrediction),
+                    'session_started' => $session && $session->isStarted(),
+                    'session_cookie_present' => $session && $request->cookies->has($session->getName()),
+                ));
+
+                break;
+            }
         }
 
         // clear the submitted POST data and reload the page

--- a/src/Devlabs/SportifyBundle/Resources/config/services.yml
+++ b/src/Devlabs/SportifyBundle/Resources/config/services.yml
@@ -8,6 +8,11 @@ services:
         calls:
             - [setContainer, ['@service_container']]
 
+    Devlabs\SportifyBundle\Controller\MatchesController:
+        arguments: ['@logger']
+        calls:
+            - [setContainer, ['@service_container']]
+
     app.form.type.prediction:
         class: Devlabs\SportifyBundle\Form\PredictionType
         arguments: ["@doctrine.orm.entity_manager"]

--- a/src/Devlabs/SportifyBundle/Resources/config/services.yml
+++ b/src/Devlabs/SportifyBundle/Resources/config/services.yml
@@ -9,7 +9,7 @@ services:
             - [setContainer, ['@service_container']]
 
     Devlabs\SportifyBundle\Controller\MatchesController:
-        arguments: ['@logger']
+        arguments: ['@monolog.logger.prediction']
         calls:
             - [setContainer, ['@service_container']]
 

--- a/tests/Functional/AdminPredictionFlowTest.php
+++ b/tests/Functional/AdminPredictionFlowTest.php
@@ -70,6 +70,43 @@ class AdminPredictionFlowTest extends FunctionalTestCase
         $this->assertSame($awayTeam->getId(), $championPrediction->getTeamId()->getId());
     }
 
+    public function testRejectedPredictionCsrfTokenIsLoggedWithSafeMetadata()
+    {
+        $admin = $this->createUser('admin_rejected_prediction', 'testpass', true, array('ROLE_ADMIN'));
+        list(, , , $match) = $this->createTournamentWithMatch();
+
+        $this->login('admin_rejected_prediction@example.com', 'testpass');
+
+        $crawler = $this->client->request('GET', '/tournaments');
+        $this->client->submit($crawler->selectButton('JOIN')->form());
+
+        $crawler = $this->client->request('GET', '/matches');
+        $form = $crawler->filter('button.match-btn')->form(array(
+            'prediction[homeGoals]' => 2,
+            'prediction[awayGoals]' => 1,
+            'prediction[_token]' => 'invalid-csrf-token',
+        ));
+        $this->client->submit($form);
+
+        $records = array_values(array_filter(
+            $this->client->getContainer()->get('monolog.handler.test')->getRecords(),
+            static function ($record) {
+                return 'prediction_csrf_rejected' === $record->message;
+            }
+        ));
+
+        $this->assertCount(1, $records);
+        $this->assertSame('WARNING', $records[0]->level->getName());
+        $this->assertSame(array(
+            'user_id' => $admin->getId(),
+            'match_id' => $match->getId(),
+            'route' => 'matches_bet',
+            'csrf_token_present' => true,
+            'session_started' => true,
+            'session_cookie_present' => true,
+        ), $records[0]->context);
+    }
+
     public function testStaleBetFormUpdatesExistingPrediction()
     {
         $admin = $this->createUser('admin_stale_prediction', 'testpass', true, array('ROLE_ADMIN'));

--- a/tests/Unit/ProductionLoggingConfigurationTest.php
+++ b/tests/Unit/ProductionLoggingConfigurationTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+class ProductionLoggingConfigurationTest extends TestCase
+{
+    public function testPredictionWarningsBypassErrorTriggeredHandler()
+    {
+        $projectDir = dirname(__DIR__, 2);
+        $baseConfig = Yaml::parseFile($projectDir.'/config/packages/monolog.yml');
+        $prodConfig = Yaml::parseFile($projectDir.'/config/packages/prod/monolog.yml');
+        $handlers = $prodConfig['monolog']['handlers'];
+
+        $this->assertContains('prediction', $baseConfig['monolog']['channels']);
+        $this->assertSame('stream', $handlers['prediction_rejections']['type']);
+        $this->assertSame('warning', $handlers['prediction_rejections']['level']);
+        $this->assertSame(array('prediction'), $handlers['prediction_rejections']['channels']);
+        $this->assertContains('!prediction', $handlers['main']['channels']);
+    }
+}


### PR DESCRIPTION
Logs safe request metadata when a prediction form is rejected for an invalid CSRF token and adds focused functional coverage. Updates the pending task list.