### PR TITLE
Route runtime warnings through Monolog

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,21 +2,17 @@
 
 ## Current status
 
-Pending tasks: 2.
+Pending tasks: 1.
 
 ## Pending
 
-For each of the following two items only, add a focused test first, run it and confirm that it fails for the expected reason, implement the fix, then run the test again and confirm that it passes.
+For the following item, add a focused test first, run it and confirm that it fails for the expected reason, implement the fix, then run the test again and confirm that it passes.
 
 1. Return explicit prediction-form error responses instead of silently redirecting.
    - Return HTTP 403 with a dedicated error page when CSRF validation fails.
    - Clearly state that the prediction was not saved and provide a prominent GET link back to the same filtered Matches page so the user receives a fresh form and token before entering the prediction again. Do not tell the user to refresh the 403 POST response because that would resubmit the stale request.
    - Return HTTP 422 with equivalent retry guidance for other prediction-form validation failures.
    - Keep successful prediction submissions unchanged: save and redirect normally without a success notification.
-
-2. Route remaining direct PHP runtime logging through the application logger.
-   - Replace the `error_log()` calls in `DataUpdateCommand` and `Telegram` with injected PSR logger warning events.
-   - Keep the existing HTTP status, reason, and exception-class diagnostics without logging response bodies, bot tokens, chat IDs, message contents, or exception messages.
 
 ## Baseline
 

--- a/config/packages/monolog.yml
+++ b/config/packages/monolog.yml
@@ -1,2 +1,2 @@
 monolog:
-    channels: ['prediction']
+    channels: ['prediction', 'operations']

--- a/config/packages/prod/monolog.yml
+++ b/config/packages/prod/monolog.yml
@@ -4,7 +4,12 @@ monolog:
             type:         fingers_crossed
             action_level: error
             handler:      nested
-            channels:     ['!prediction']
+            channels:     ['!prediction', '!operations']
+        operational_warnings:
+            type:     stream
+            path:     "%kernel.logs_dir%/%kernel.environment%.log"
+            level:    warning
+            channels: ['operations']
         prediction_rejections:
             type:     stream
             path:     "%kernel.logs_dir%/%kernel.environment%.log"

--- a/src/Devlabs/SportifyBundle/Command/DataUpdateCommand.php
+++ b/src/Devlabs/SportifyBundle/Command/DataUpdateCommand.php
@@ -5,6 +5,7 @@ namespace Devlabs\SportifyBundle\Command;
 use Devlabs\SportifyBundle\Entity\MatchEntity;
 use Devlabs\SportifyBundle\Entity\Prediction;
 use Devlabs\SportifyBundle\Entity\Score;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -18,11 +19,13 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class DataUpdateCommand extends Command
 {
     private $container;
+    private $logger;
 
-    public function __construct(ContainerInterface $container)
+    public function __construct(ContainerInterface $container, LoggerInterface $logger)
     {
         parent::__construct();
         $this->container = $container;
+        $this->logger = $logger;
     }
 
     protected function configure(): void
@@ -138,10 +141,9 @@ class DataUpdateCommand extends Command
                 if ($this->shouldPinTelegramMessages() && isset($telegramResult['result']['message_id'])) {
                     $pinResponse = $telegram->pinMessage($telegramResult['result']['message_id']);
                     if ($pinResponse->getStatusCode() < 200 || $pinResponse->getStatusCode() >= 300) {
-                        error_log(sprintf(
-                            'Telegram message pinning failed (HTTP %d %s).',
-                            $pinResponse->getStatusCode(),
-                            $pinResponse->getReasonPhrase()
+                        $this->logger->warning('telegram_message_pinning_failed', array(
+                            'status_code' => $pinResponse->getStatusCode(),
+                            'reason' => $pinResponse->getReasonPhrase(),
                         ));
                     }
                 }

--- a/src/Devlabs/SportifyBundle/Resources/config/services.yml
+++ b/src/Devlabs/SportifyBundle/Resources/config/services.yml
@@ -68,7 +68,7 @@ services:
 
     app.telegram:
         class: Devlabs\SportifyBundle\Services\Telegram
-        arguments: ['@service_container', '%telegram.bot_token%', '%telegram.chat_id%']
+        arguments: ['@service_container', '%telegram.bot_token%', '%telegram.chat_id%', '@monolog.logger.operations']
 
     app.prediction_scorer:
         class: Devlabs\SportifyBundle\Services\PredictionScorer
@@ -165,7 +165,7 @@ services:
 
     app.command.data_update:
         class: Devlabs\SportifyBundle\Command\DataUpdateCommand
-        arguments: ['@service_container']
+        arguments: ['@service_container', '@monolog.logger.operations']
         tags:
             - { name: console.command }
 

--- a/src/Devlabs/SportifyBundle/Services/Telegram.php
+++ b/src/Devlabs/SportifyBundle/Services/Telegram.php
@@ -5,6 +5,7 @@ namespace Devlabs\SportifyBundle\Services;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Response;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareTrait;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -19,13 +20,15 @@ class Telegram
     private $httpClient;
     private $botToken;
     private $chatId;
+    private $logger;
 
-    public function __construct(ContainerInterface $container, $botToken, $chatId)
+    public function __construct(ContainerInterface $container, $botToken, $chatId, LoggerInterface $logger)
     {
         $this->httpClient = new Client();
         $this->botToken = $botToken;
         $this->chatId = $chatId;
         $this->container = $container;
+        $this->logger = $logger;
     }
 
     /**
@@ -135,16 +138,15 @@ class Telegram
 
     private function logAdminNotificationFailure(Response $response, ?\Exception $exception = null)
     {
-        $message = sprintf(
-            'Telegram admin notification failed (HTTP %d %s).',
-            $response->getStatusCode(),
-            $response->getReasonPhrase()
+        $context = array(
+            'status_code' => $response->getStatusCode(),
+            'reason' => $response->getReasonPhrase(),
         );
         if ($exception !== null) {
-            $message .= ' Exception: '.get_class($exception);
+            $context['exception_class'] = get_class($exception);
         }
 
-        error_log($message);
+        $this->logger->warning('telegram_admin_notification_failed', $context);
     }
 
     private function getAdminChatId()

--- a/tests/Unit/DataUpdateCommandTest.php
+++ b/tests/Unit/DataUpdateCommandTest.php
@@ -11,6 +11,7 @@ use Devlabs\SportifyBundle\Entity\Tournament;
 use Devlabs\SportifyBundle\Entity\User;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\Container;
@@ -25,7 +26,7 @@ class DataUpdateCommandTest extends TestCase
 
         $this->configureContainer($container, $slack, $telegram);
 
-        $tester = new CommandTester(new DataUpdateCommand($container));
+        $tester = new CommandTester(new DataUpdateCommand($container, new FakeDataUpdateLogger()));
         $tester->execute(array(
             'type' => 'matches-fixtures',
             'days' => 3,
@@ -48,7 +49,7 @@ class DataUpdateCommandTest extends TestCase
         $this->configureContainer($container, $slack, $telegram);
         $container->setParameter('telegram.pin_messages', null);
 
-        $tester = new CommandTester(new DataUpdateCommand($container));
+        $tester = new CommandTester(new DataUpdateCommand($container, new FakeDataUpdateLogger()));
         $tester->execute(array(
             'type' => 'matches-fixtures',
             'days' => 3,
@@ -68,7 +69,7 @@ class DataUpdateCommandTest extends TestCase
         $this->configureContainer($container, $slack, $telegram);
         $container->setParameter('telegram.pin_messages', false);
 
-        $tester = new CommandTester(new DataUpdateCommand($container));
+        $tester = new CommandTester(new DataUpdateCommand($container, new FakeDataUpdateLogger()));
         $tester->execute(array(
             'type' => 'matches-fixtures',
             'days' => 3,
@@ -77,6 +78,33 @@ class DataUpdateCommandTest extends TestCase
         $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
         $this->assertCount(1, $telegram->messages);
         $this->assertSame(array(), $telegram->pinnedMessageIds);
+    }
+
+    public function testLogsFailedTelegramMessagePinning()
+    {
+        $container = new Container();
+        $slack = new FakeDataUpdateSlack();
+        $telegram = new FakeDataUpdateTelegram();
+        $telegram->pinResponse = new Response(500, array(), null, '1.1', 'Pin Failed');
+        $logger = new FakeDataUpdateLogger();
+
+        $this->configureContainer($container, $slack, $telegram);
+
+        $tester = new CommandTester(new DataUpdateCommand($container, $logger));
+        $tester->execute(array(
+            'type' => 'matches-fixtures',
+            'days' => 3,
+        ));
+
+        $this->assertSame(Command::SUCCESS, $tester->getStatusCode());
+        $this->assertSame(array(array(
+            'level' => 'warning',
+            'message' => 'telegram_message_pinning_failed',
+            'context' => array(
+                'status_code' => 500,
+                'reason' => 'Pin Failed',
+            ),
+        )), $logger->records);
     }
 
     public function testResultUpdateNotificationIncludesScoringBreakdown()
@@ -92,7 +120,7 @@ class DataUpdateCommandTest extends TestCase
         $container->set('app.slack', $slack);
         $container->set('app.telegram', $telegram);
 
-        $tester = new CommandTester(new DataUpdateCommand($container));
+        $tester = new CommandTester(new DataUpdateCommand($container, new FakeDataUpdateLogger()));
         $tester->execute(array(
             'type' => 'matches-results',
             'days' => 1,
@@ -122,7 +150,7 @@ class DataUpdateCommandTest extends TestCase
         $container->set('app.slack', $slack);
         $container->set('app.telegram', $telegram);
 
-        $tester = new CommandTester(new DataUpdateCommand($container));
+        $tester = new CommandTester(new DataUpdateCommand($container, new FakeDataUpdateLogger()));
         $tester->execute(array(
             'type' => 'matches-results',
             'days' => 1,
@@ -376,10 +404,25 @@ class FakeDataUpdateSlack
     }
 }
 
+class FakeDataUpdateLogger extends AbstractLogger
+{
+    public $records = array();
+
+    public function log($level, $message, array $context = array()): void
+    {
+        $this->records[] = array(
+            'level' => $level,
+            'message' => $message,
+            'context' => $context,
+        );
+    }
+}
+
 class FakeDataUpdateTelegram
 {
     public $messages = array();
     public $pinnedMessageIds = array();
+    public $pinResponse;
 
     public function sendMessage($text)
     {
@@ -396,6 +439,6 @@ class FakeDataUpdateTelegram
     {
         $this->pinnedMessageIds[] = $messageId;
 
-        return new Response(200);
+        return $this->pinResponse ?: new Response(200);
     }
 }

--- a/tests/Unit/ProductionLoggingConfigurationTest.php
+++ b/tests/Unit/ProductionLoggingConfigurationTest.php
@@ -7,6 +7,20 @@ use Symfony\Component\Yaml\Yaml;
 
 class ProductionLoggingConfigurationTest extends TestCase
 {
+    public function testOperationalWarningsBypassErrorTriggeredHandler()
+    {
+        $projectDir = dirname(__DIR__, 2);
+        $baseConfig = Yaml::parseFile($projectDir.'/config/packages/monolog.yml');
+        $prodConfig = Yaml::parseFile($projectDir.'/config/packages/prod/monolog.yml');
+        $handlers = $prodConfig['monolog']['handlers'];
+
+        $this->assertContains('operations', $baseConfig['monolog']['channels']);
+        $this->assertSame('stream', $handlers['operational_warnings']['type']);
+        $this->assertSame('warning', $handlers['operational_warnings']['level']);
+        $this->assertSame(array('operations'), $handlers['operational_warnings']['channels']);
+        $this->assertContains('!operations', $handlers['main']['channels']);
+    }
+
     public function testPredictionWarningsBypassErrorTriggeredHandler()
     {
         $projectDir = dirname(__DIR__, 2);

--- a/tests/Unit/TelegramTest.php
+++ b/tests/Unit/TelegramTest.php
@@ -7,10 +7,18 @@ use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\AbstractLogger;
 use Symfony\Component\DependencyInjection\Container;
 
 class TelegramTest extends TestCase
 {
+    private $logger;
+
+    protected function setUp(): void
+    {
+        $this->logger = new FakeTelegramLogger();
+    }
+
     public function testSendAdminMessageDoesNotUseMarkdownParseMode()
     {
         $telegram = $this->createTelegram($client = new FakeTelegramHttpClient());
@@ -27,57 +35,46 @@ class TelegramTest extends TestCase
     {
         $telegram = $this->createTelegram(new FailingTelegramHttpClient());
 
-        list($response, $log) = $this->captureErrorLog(function () use ($telegram) {
-            return $telegram->sendAdminMessage('External API failure');
-        });
+        $response = $telegram->sendAdminMessage('External API failure');
 
         $this->assertSame(500, $response->getStatusCode());
         $this->assertSame('Telegram admin notification failed', $response->getReasonPhrase());
-        $this->assertStringContainsString('Telegram admin notification failed (HTTP 500 Telegram admin notification failed). Exception: GuzzleHttp\\Exception\\ConnectException', $log);
-        $this->assertStringNotContainsString('bot-token', $log);
-        $this->assertStringNotContainsString('/botbot-token/sendMessage', $log);
+        $this->assertSame(array(array(
+            'level' => 'warning',
+            'message' => 'telegram_admin_notification_failed',
+            'context' => array(
+                'status_code' => 500,
+                'reason' => 'Telegram admin notification failed',
+                'exception_class' => ConnectException::class,
+            ),
+        )), $this->logger->records);
     }
 
     public function testSendAdminMessageLogsNonSuccessResponse()
     {
         $telegram = $this->createTelegram(new UnsuccessfulTelegramHttpClient());
 
-        list($response, $log) = $this->captureErrorLog(function () use ($telegram) {
-            return $telegram->sendAdminMessage('External API failure');
-        });
+        $response = $telegram->sendAdminMessage('External API failure');
 
         $this->assertSame(400, $response->getStatusCode());
-        $this->assertStringContainsString('Telegram admin notification failed (HTTP 400 Bad Request).', $log);
+        $this->assertSame(array(array(
+            'level' => 'warning',
+            'message' => 'telegram_admin_notification_failed',
+            'context' => array(
+                'status_code' => 400,
+                'reason' => 'Bad Request',
+            ),
+        )), $this->logger->records);
     }
 
     public function testSendAdminMessageDoesNotLogWhenAdminChatIsDisabled()
     {
         $telegram = $this->createTelegram(new FailingTelegramHttpClient(), 'check_the_README_file');
 
-        list($response, $log) = $this->captureErrorLog(function () use ($telegram) {
-            return $telegram->sendAdminMessage('External API failure');
-        });
+        $response = $telegram->sendAdminMessage('External API failure');
 
         $this->assertSame(400, $response->getStatusCode());
-        $this->assertSame('', $log);
-    }
-
-    private function captureErrorLog(callable $callback)
-    {
-        $logFile = tempnam(sys_get_temp_dir(), 'telegram-error-log-');
-        $previousLog = ini_set('error_log', $logFile);
-
-        try {
-            $result = $callback();
-            $log = file_exists($logFile) ? file_get_contents($logFile) : '';
-        } finally {
-            ini_set('error_log', $previousLog);
-            if (file_exists($logFile)) {
-                unlink($logFile);
-            }
-        }
-
-        return array($result, $log);
+        $this->assertSame(array(), $this->logger->records);
     }
 
     private function createTelegram($client, $adminChatId = 'admin-chat')
@@ -86,12 +83,26 @@ class TelegramTest extends TestCase
         $container->set('kernel', new FakeTelegramKernel());
         $container->setParameter('telegram.admin_chat_id', $adminChatId);
 
-        $telegram = new Telegram($container, 'bot-token', 'main-chat');
+        $telegram = new Telegram($container, 'bot-token', 'main-chat', $this->logger);
         $property = new \ReflectionProperty(Telegram::class, 'httpClient');
         $property->setAccessible(true);
         $property->setValue($telegram, $client);
 
         return $telegram;
+    }
+}
+
+class FakeTelegramLogger extends AbstractLogger
+{
+    public $records = array();
+
+    public function log($level, $message, array $context = array()): void
+    {
+        $this->records[] = array(
+            'level' => $level,
+            'message' => $message,
+            'context' => $context,
+        );
     }
 }
 


### PR DESCRIPTION
Replaces the remaining direct PHP runtime logging with structured PSR logger events and ensures operational warnings persist in production.