### PR TITLE
Return explicit prediction form errors

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,17 +2,11 @@
 
 ## Current status
 
-Pending tasks: 1.
+Pending tasks: 0.
 
 ## Pending
 
-For the following item, add a focused test first, run it and confirm that it fails for the expected reason, implement the fix, then run the test again and confirm that it passes.
-
-1. Return explicit prediction-form error responses instead of silently redirecting.
-   - Return HTTP 403 with a dedicated error page when CSRF validation fails.
-   - Clearly state that the prediction was not saved and provide a prominent GET link back to the same filtered Matches page so the user receives a fresh form and token before entering the prediction again. Do not tell the user to refresh the 403 POST response because that would resubmit the stale request.
-   - Return HTTP 422 with equivalent retry guidance for other prediction-form validation failures.
-   - Keep successful prediction submissions unchanged: save and redirect normally without a success notification.
+None.
 
 ## Baseline
 

--- a/app/Resources/views/Matches/prediction_error.html.twig
+++ b/app/Resources/views/Matches/prediction_error.html.twig
@@ -1,0 +1,18 @@
+{% extends 'base.html.twig' %}
+
+{% block nav_top %}
+    <h1 class="text-center">Prediction not saved</h1>
+{% endblock %}
+
+{% block body %}
+    <div class="container-fluid content">
+        <div class="prediction-error row text-center">
+            <div class="col-sm-8 col-sm-offset-2">
+                <h2>Prediction not saved</h2>
+                <p>{{ message }}</p>
+                <p>Return to Matches to load a fresh form before entering your prediction again.</p>
+                <a class="btn green-btn" href="{{ retry_url }}">Return to Matches</a>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/app/Resources/views/Matches/prediction_error.html.twig
+++ b/app/Resources/views/Matches/prediction_error.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base.html.twig' %}
 
 {% block nav_top %}
-    <h1 class="text-center">Prediction not saved</h1>
+    <h1 class="text-center">Warning</h1>
 {% endblock %}
 
 {% block body %}

--- a/src/Devlabs/SportifyBundle/Controller/MatchesController.php
+++ b/src/Devlabs/SportifyBundle/Controller/MatchesController.php
@@ -7,6 +7,7 @@ use Devlabs\SportifyBundle\Entity\Prediction;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Csrf\CsrfToken;
 
 /**
@@ -143,11 +144,13 @@ class MatchesController extends AbstractController
         }
 
         if ($form->isSubmitted() && !$form->isValid()) {
+            $csrfRejected = false;
             foreach ($form->getErrors(true) as $error) {
                 if (!($error->getCause() instanceof CsrfToken)) {
                     continue;
                 }
 
+                $csrfRejected = true;
                 $session = $request->hasSession() ? $request->getSession() : null;
                 $this->logger->warning('prediction_csrf_rejected', array(
                     'user_id' => $user->getId(),
@@ -160,6 +163,20 @@ class MatchesController extends AbstractController
 
                 break;
             }
+
+            $statusCode = $csrfRejected ? Response::HTTP_FORBIDDEN : Response::HTTP_UNPROCESSABLE_ENTITY;
+            $message = $csrfRejected
+                ? 'Your prediction was not saved because the form could not be verified.'
+                : 'Your prediction was not saved because the submitted values were invalid.';
+
+            return $this->render(
+                'Matches/prediction_error.html.twig',
+                array(
+                    'message' => $message,
+                    'retry_url' => $this->generateUrl('matches_index', $urlParams),
+                ),
+                new Response('', $statusCode)
+            );
         }
 
         // clear the submitted POST data and reload the page

--- a/tests/Functional/AdminPredictionFlowTest.php
+++ b/tests/Functional/AdminPredictionFlowTest.php
@@ -74,19 +74,30 @@ class AdminPredictionFlowTest extends FunctionalTestCase
     {
         $admin = $this->createUser('admin_rejected_prediction', 'testpass', true, array('ROLE_ADMIN'));
         list(, , , $match) = $this->createTournamentWithMatch();
+        $matchesPath = '/matches/index/all/'.date('Y-m-d').'/'.date('Y-m-d', strtotime('+14 days'));
 
         $this->login('admin_rejected_prediction@example.com', 'testpass');
 
         $crawler = $this->client->request('GET', '/tournaments');
         $this->client->submit($crawler->selectButton('JOIN')->form());
 
-        $crawler = $this->client->request('GET', '/matches');
+        $crawler = $this->client->request('GET', $matchesPath);
         $form = $crawler->filter('button.match-btn')->form(array(
             'prediction[homeGoals]' => 2,
             'prediction[awayGoals]' => 1,
             'prediction[_token]' => 'invalid-csrf-token',
         ));
-        $this->client->submit($form);
+        $crawler = $this->client->submit($form);
+
+        $this->assertSame(403, $this->client->getResponse()->getStatusCode());
+        $this->assertStringContainsString('Your prediction was not saved because the form could not be verified.', $crawler->text());
+        $this->assertSame(1, $crawler->filter('.prediction-error a.btn.green-btn')->count());
+        $this->assertSame($matchesPath, $crawler->selectLink('Return to Matches')->attr('href'));
+        $this->assertStringNotContainsString('refresh', strtolower($crawler->text()));
+        $this->assertNull($this->em->getRepository(Prediction::class)->findOneBy(array(
+            'userId' => $admin,
+            'matchId' => $match,
+        )));
 
         $records = array_values(array_filter(
             $this->client->getContainer()->get('monolog.handler.test')->getRecords(),
@@ -105,6 +116,35 @@ class AdminPredictionFlowTest extends FunctionalTestCase
             'session_started' => true,
             'session_cookie_present' => true,
         ), $records[0]->context);
+    }
+
+    public function testInvalidPredictionValuesReturnUnprocessableResponse()
+    {
+        $admin = $this->createUser('admin_invalid_prediction', 'testpass', true, array('ROLE_ADMIN'));
+        list(, , , $match) = $this->createTournamentWithMatch();
+        $matchesPath = '/matches/index/all/'.date('Y-m-d').'/'.date('Y-m-d', strtotime('+14 days'));
+
+        $this->login('admin_invalid_prediction@example.com', 'testpass');
+
+        $crawler = $this->client->request('GET', '/tournaments');
+        $this->client->submit($crawler->selectButton('JOIN')->form());
+
+        $crawler = $this->client->request('GET', $matchesPath);
+        $form = $crawler->filter('button.match-btn')->form(array(
+            'prediction[homeGoals]' => 'not-a-number',
+            'prediction[awayGoals]' => 1,
+        ));
+        $crawler = $this->client->submit($form);
+
+        $this->assertSame(422, $this->client->getResponse()->getStatusCode());
+        $this->assertStringContainsString('Your prediction was not saved because the submitted values were invalid.', $crawler->text());
+        $this->assertSame(1, $crawler->filter('.prediction-error a.btn.green-btn')->count());
+        $this->assertSame($matchesPath, $crawler->selectLink('Return to Matches')->attr('href'));
+        $this->assertStringNotContainsString('refresh', strtolower($crawler->text()));
+        $this->assertNull($this->em->getRepository(Prediction::class)->findOneBy(array(
+            'userId' => $admin,
+            'matchId' => $match,
+        )));
     }
 
     public function testStaleBetFormUpdatesExistingPrediction()


### PR DESCRIPTION
Returns dedicated 403 and 422 responses for rejected prediction forms with a safe link back to the same filtered Matches page. Successful submissions remain unchanged.